### PR TITLE
Fix sanctioned address filtering for create txs

### DIFF
--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -729,14 +729,17 @@ func (s *Server) filterSanctionedAddresses(ctx context.Context, req *RPCReq) err
 		return err
 	}
 
-	to := *tx.To()
-
 	if _, ok := s.sanctionedAddresses[*from]; ok {
 		log.Debug("sender is sanctioned", "sender", from, "req_id", GetReqID(ctx))
 		return ErrSanctionedAddress
-	} else if _, ok := s.sanctionedAddresses[to]; ok {
-		log.Debug("recipient is sanctioned", "recipient", to, "req_id", GetReqID(ctx))
-		return ErrSanctionedAddress
+	}
+	to := tx.To()
+	// Create transactions do not have a "to" address so in this case "to" can be nil.
+	if to != nil {
+		if _, ok := s.sanctionedAddresses[*to]; ok {
+			log.Debug("recipient is sanctioned", "recipient", to, "req_id", GetReqID(ctx))
+			return ErrSanctionedAddress
+		}
 	}
 
 	return nil

--- a/proxyd/server_test.go
+++ b/proxyd/server_test.go
@@ -108,7 +108,7 @@ func TestFilterSanctionedAddresses(t *testing.T) {
 			expected: nil,
 		},
 		{
-			name: "Create tx with non sanctiond address",
+			name: "Create tx with non sanctioned address",
 			req: &RPCReq{
 				Params: json.RawMessage(fmt.Sprintf(`["%s"]`, makeContractCreationTransaction(t))),
 			},


### PR DESCRIPTION
This PR ensures that the sanctioned address filtering code does not try to dereference the `to` field of a transaction if it is null, which happens for create transactions.