### PR TITLE
proxyd: allow consensus_max_block_lag to be set to 0

### DIFF
--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -176,7 +176,7 @@ type BackendGroupConfig struct {
 
 	ConsensusBanPeriod          TOMLDuration `toml:"consensus_ban_period"`
 	ConsensusMaxUpdateThreshold TOMLDuration `toml:"consensus_max_update_threshold"`
-	ConsensusMaxBlockLag        uint64       `toml:"consensus_max_block_lag"`
+	ConsensusMaxBlockLag        *uint64      `toml:"consensus_max_block_lag"`
 	ConsensusMaxBlockRange      uint64       `toml:"consensus_max_block_range"`
 	ConsensusMinPeerCount       int          `toml:"consensus_min_peer_count"`
 

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -429,8 +429,8 @@ func Start(config *Config) (*Server, func(), error) {
 			if bgcfg.ConsensusMaxUpdateThreshold > 0 {
 				copts = append(copts, WithMaxUpdateThreshold(time.Duration(bgcfg.ConsensusMaxUpdateThreshold)))
 			}
-			if bgcfg.ConsensusMaxBlockLag > 0 {
-				copts = append(copts, WithMaxBlockLag(bgcfg.ConsensusMaxBlockLag))
+			if bgcfg.ConsensusMaxBlockLag != nil {
+				copts = append(copts, WithMaxBlockLag(*bgcfg.ConsensusMaxBlockLag))
 			}
 			if bgcfg.ConsensusMinPeerCount > 0 {
 				copts = append(copts, WithMinPeerCount(uint64(bgcfg.ConsensusMinPeerCount)))


### PR DESCRIPTION
Change ConsensusMaxBlockLag from uint64 to *uint64 so that an explicit 0 in config is distinguishable from "not set" (which falls back to the default of 8). This enables zero-tolerance block lag for testnet environments.
