### PR TITLE
Add support for espresso tag and test

### DIFF
--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -1794,6 +1794,8 @@ func (bg *BackendGroup) OverwriteConsensusResponses(rpcReqs []*RPCReq, overridde
 		safe:          bg.Consensus.GetSafeBlockNumber(),
 		finalized:     bg.Consensus.GetFinalizedBlockNumber(),
 		maxBlockRange: bg.Consensus.maxBlockRange,
+		espressoTag:   bg.Consensus.espressoTag,
+		espresso:      bg.Consensus.GetEspressoBlockNumber(),
 	}
 
 	for i, req := range rpcReqs {

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -185,6 +185,12 @@ type BackendGroupConfig struct {
 	ConsensusHALockPeriod        TOMLDuration `toml:"consensus_ha_lock_period"`
 	ConsensusHARedis             RedisConfig  `toml:"consensus_ha_redis"`
 
+	// consensus_espresso_tag, if set, enables Espresso-finality consensus: the poller
+	// calls eth_getBlockByNumber(<tag>, false) on each backend each cycle and tracks
+	// the minimum resolved block across healthy backends. Requests containing this tag
+	// are rewritten to that consensus block number before forwarding.
+	ConsensusEspressoTag string `toml:"consensus_espresso_tag"`
+
 	Fallbacks                  []string `toml:"fallbacks"`
 	RestrictArchiveNodeTraffic bool     `toml:"restrict_archive_node_traffic"`
 	ArchiveBlockThreshold      uint64   `toml:"archive_block_threshold"`

--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -40,6 +40,11 @@ type ConsensusPoller struct {
 	maxBlockLag        uint64
 	maxBlockRange      uint64
 	interval           time.Duration
+
+	// espressoTag, when non-empty, enables Espresso-finality consensus polling.
+	// Each backend is queried with eth_getBlockByNumber(<espressoTag>, false) every cycle;
+	// the minimum resolved block across healthy backends is stored in the tracker.
+	espressoTag string
 }
 
 type backendState struct {
@@ -49,6 +54,7 @@ type backendState struct {
 	latestBlockHash      string
 	safeBlockNumber      hexutil.Uint64
 	finalizedBlockNumber hexutil.Uint64
+	espressoBlockNumber  hexutil.Uint64
 
 	peerCount uint64
 	inSync    bool
@@ -104,6 +110,12 @@ func (ct *ConsensusPoller) GetSafeBlockNumber() hexutil.Uint64 {
 // GetFinalizedBlockNumber returns the `finalized` agreed block number in a consensus
 func (ct *ConsensusPoller) GetFinalizedBlockNumber() hexutil.Uint64 {
 	return ct.tracker.GetFinalizedBlockNumber()
+}
+
+// GetEspressoBlockNumber returns the minimum Espresso-finalized block number in consensus.
+// Returns 0 when espressoTag is not configured or not yet resolved.
+func (cp *ConsensusPoller) GetEspressoBlockNumber() hexutil.Uint64 {
+	return cp.tracker.GetEspressoBlockNumber()
 }
 
 func (cp *ConsensusPoller) Shutdown() {
@@ -266,6 +278,12 @@ func WithPollerInterval(interval time.Duration) ConsensusOpt {
 	}
 }
 
+func WithEspressoTag(tag string) ConsensusOpt {
+	return func(cp *ConsensusPoller) {
+		cp.espressoTag = tag
+	}
+}
+
 func NewConsensusPoller(bg *BackendGroup, opts ...ConsensusOpt) *ConsensusPoller {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 
@@ -376,11 +394,21 @@ func (cp *ConsensusPoller) UpdateBackend(ctx context.Context, be *Backend) {
 		return
 	}
 
+	var espressoBlockNumber hexutil.Uint64
+	if cp.espressoTag != "" {
+		espressoNum, _, espressoErr := cp.fetchBlock(ctx, be, cp.espressoTag)
+		if espressoErr != nil {
+			log.Warn("error fetching espresso block from backend (skipping)", "name", be.Name, "tag", cp.espressoTag, "err", espressoErr)
+		} else {
+			espressoBlockNumber = espressoNum
+		}
+	}
+
 	RecordConsensusBackendUpdateDelay(be, bs.lastUpdate)
 
 	changed := cp.setBackendState(be, peerCount, inSync,
 		latestBlockNumber, latestBlockHash,
-		safeBlockNumber, finalizedBlockNumber)
+		safeBlockNumber, finalizedBlockNumber, espressoBlockNumber)
 
 	RecordBackendLatestBlock(be, latestBlockNumber)
 	RecordBackendSafeBlock(be, safeBlockNumber)
@@ -448,6 +476,7 @@ func (cp *ConsensusPoller) UpdateBackendGroupConsensus(ctx context.Context) {
 	var lowestLatestBlockHash string
 	var lowestFinalizedBlock hexutil.Uint64
 	var lowestSafeBlock hexutil.Uint64
+	var lowestEspressoBlock hexutil.Uint64 // only populated when espressoTag is configured
 	for _, bs := range candidates {
 		if lowestLatestBlock == 0 || bs.latestBlockNumber < lowestLatestBlock {
 			lowestLatestBlock = bs.latestBlockNumber
@@ -458,6 +487,11 @@ func (cp *ConsensusPoller) UpdateBackendGroupConsensus(ctx context.Context) {
 		}
 		if lowestSafeBlock == 0 || bs.safeBlockNumber < lowestSafeBlock {
 			lowestSafeBlock = bs.safeBlockNumber
+		}
+		if cp.espressoTag != "" && bs.espressoBlockNumber > 0 {
+			if lowestEspressoBlock == 0 || bs.espressoBlockNumber < lowestEspressoBlock {
+				lowestEspressoBlock = bs.espressoBlockNumber
+			}
 		}
 	}
 
@@ -522,10 +556,16 @@ func (cp *ConsensusPoller) UpdateBackendGroupConsensus(ctx context.Context) {
 			"proposedBlockHash", proposedBlockHash)
 	}
 
+	// For espresso tag enabled, do not move backwards if a proxy restarts
+	if currentEspresso := cp.tracker.GetEspressoBlockNumber(); lowestEspressoBlock < currentEspresso {
+		lowestEspressoBlock = currentEspresso
+	}
+
 	// update tracker
 	cp.tracker.SetLatestBlockNumber(proposedBlock)
 	cp.tracker.SetSafeBlockNumber(lowestSafeBlock)
 	cp.tracker.SetFinalizedBlockNumber(lowestFinalizedBlock)
+	cp.tracker.SetEspressoBlockNumber(lowestEspressoBlock)
 
 	// update consensus group
 	group := make([]*Backend, 0, len(candidates))
@@ -553,10 +593,19 @@ func (cp *ConsensusPoller) UpdateBackendGroupConsensus(ctx context.Context) {
 	RecordGroupConsensusFilteredCount(cp.backendGroup, len(filteredBackendsNames))
 	RecordGroupTotalCount(cp.backendGroup, len(cp.backendGroup.Backends))
 
-	log.Debug("group state",
-		"proposedBlock", proposedBlock,
-		"consensusBackends", strings.Join(consensusBackendsNames, ", "),
-		"filteredBackends", strings.Join(filteredBackendsNames, ", "))
+	if cp.espressoTag != "" {
+		log.Debug("espresso consensus cycle complete",
+			"proposedBlock", proposedBlock,
+			"espressoBlock", lowestEspressoBlock,
+			"espressoTag", cp.espressoTag,
+			"consensusBackends", strings.Join(consensusBackendsNames, ", "),
+			"filteredBackends", strings.Join(filteredBackendsNames, ", "))
+	} else {
+		log.Debug("group state",
+			"proposedBlock", proposedBlock,
+			"consensusBackends", strings.Join(consensusBackendsNames, ", "),
+			"filteredBackends", strings.Join(filteredBackendsNames, ", "))
+	}
 }
 
 // IsBanned checks if a specific backend is banned
@@ -590,6 +639,7 @@ func (cp *ConsensusPoller) Ban(be *Backend) {
 	bs.latestBlockNumber = 0
 	bs.safeBlockNumber = 0
 	bs.finalizedBlockNumber = 0
+	bs.espressoBlockNumber = 0
 }
 
 // Unban removes any bans from the backends
@@ -681,6 +731,7 @@ func (cp *ConsensusPoller) GetBackendState(be *Backend) *backendState {
 		latestBlockHash:      bs.latestBlockHash,
 		safeBlockNumber:      bs.safeBlockNumber,
 		finalizedBlockNumber: bs.finalizedBlockNumber,
+		espressoBlockNumber:  bs.espressoBlockNumber,
 		peerCount:            bs.peerCount,
 		inSync:               bs.inSync,
 		lastUpdate:           bs.lastUpdate,
@@ -698,7 +749,8 @@ func (cp *ConsensusPoller) GetLastUpdate(be *Backend) time.Time {
 func (cp *ConsensusPoller) setBackendState(be *Backend, peerCount uint64, inSync bool,
 	latestBlockNumber hexutil.Uint64, latestBlockHash string,
 	safeBlockNumber hexutil.Uint64,
-	finalizedBlockNumber hexutil.Uint64) bool {
+	finalizedBlockNumber hexutil.Uint64,
+	espressoBlockNumber hexutil.Uint64) bool {
 	bs := cp.backendState[be]
 	bs.backendStateMux.Lock()
 	changed := bs.latestBlockHash != latestBlockHash
@@ -708,6 +760,7 @@ func (cp *ConsensusPoller) setBackendState(be *Backend, peerCount uint64, inSync
 	bs.latestBlockHash = latestBlockHash
 	bs.finalizedBlockNumber = finalizedBlockNumber
 	bs.safeBlockNumber = safeBlockNumber
+	bs.espressoBlockNumber = espressoBlockNumber
 	bs.lastUpdate = time.Now()
 	bs.backendStateMux.Unlock()
 	return changed

--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -821,6 +821,10 @@ func (cp *ConsensusPoller) FilterCandidates(backends []*Backend) map[*Backend]*b
 		if bs.lastUpdate.Add(cp.maxUpdateThreshold).Before(time.Now()) {
 			continue
 		}
+		// espresso block is 0 (fetch failed), exclude until it recovers
+		if cp.espressoTag != "" && bs.espressoBlockNumber == 0 {
+			continue
+		}
 
 		candidates[be] = bs
 	}

--- a/proxyd/consensus_tracker.go
+++ b/proxyd/consensus_tracker.go
@@ -24,6 +24,8 @@ type ConsensusTracker interface {
 	SetSafeBlockNumber(blockNumber hexutil.Uint64)
 	GetFinalizedBlockNumber() hexutil.Uint64
 	SetFinalizedBlockNumber(blockNumber hexutil.Uint64)
+	GetEspressoBlockNumber() hexutil.Uint64
+	SetEspressoBlockNumber(blockNumber hexutil.Uint64)
 }
 
 // DTO to hold the current consensus state
@@ -31,6 +33,7 @@ type ConsensusTrackerState struct {
 	Latest    hexutil.Uint64 `json:"latest"`
 	Safe      hexutil.Uint64 `json:"safe"`
 	Finalized hexutil.Uint64 `json:"finalized"`
+	Espresso  hexutil.Uint64 `json:"espresso,omitempty"`
 }
 
 func (ct *InMemoryConsensusTracker) update(o *ConsensusTrackerState) {
@@ -40,6 +43,7 @@ func (ct *InMemoryConsensusTracker) update(o *ConsensusTrackerState) {
 	ct.state.Latest = o.Latest
 	ct.state.Safe = o.Safe
 	ct.state.Finalized = o.Finalized
+	ct.state.Espresso = o.Espresso
 }
 
 // InMemoryConsensusTracker store and retrieve in memory, async-safe
@@ -107,6 +111,20 @@ func (ct *InMemoryConsensusTracker) SetFinalizedBlockNumber(blockNumber hexutil.
 	ct.mutex.Lock()
 
 	ct.state.Finalized = blockNumber
+}
+
+func (ct *InMemoryConsensusTracker) GetEspressoBlockNumber() hexutil.Uint64 {
+	defer ct.mutex.Unlock()
+	ct.mutex.Lock()
+
+	return ct.state.Espresso
+}
+
+func (ct *InMemoryConsensusTracker) SetEspressoBlockNumber(blockNumber hexutil.Uint64) {
+	defer ct.mutex.Unlock()
+	ct.mutex.Lock()
+
+	ct.state.Espresso = blockNumber
 }
 
 // RedisConsensusTracker store and retrieve in a shared Redis cluster, with leader election
@@ -318,6 +336,14 @@ func (ct *RedisConsensusTracker) GetFinalizedBlockNumber() hexutil.Uint64 {
 
 func (ct *RedisConsensusTracker) SetFinalizedBlockNumber(blockNumber hexutil.Uint64) {
 	ct.local.SetFinalizedBlockNumber(blockNumber)
+}
+
+func (ct *RedisConsensusTracker) GetEspressoBlockNumber() hexutil.Uint64 {
+	return ct.remote.GetEspressoBlockNumber()
+}
+
+func (ct *RedisConsensusTracker) SetEspressoBlockNumber(blockNumber hexutil.Uint64) {
+	ct.local.SetEspressoBlockNumber(blockNumber)
 }
 
 func (ct *RedisConsensusTracker) postPayload(mutexVal string) {

--- a/proxyd/integration_tests/consensus_espresso_test.go
+++ b/proxyd/integration_tests/consensus_espresso_test.go
@@ -1,0 +1,253 @@
+package integration_tests
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/ethereum-optimism/infra/proxyd"
+	ms "github.com/ethereum-optimism/infra/proxyd/tools/mockserver/handler"
+	"github.com/stretchr/testify/require"
+)
+
+func setupEspresso(t *testing.T) (map[string]nodeContext, *proxyd.BackendGroup, *ProxydHTTPClient, func()) {
+	node1 := NewMockBackend(nil)
+	node2 := NewMockBackend(nil)
+
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+
+	responses := path.Join(dir, "testdata/consensus_espresso_responses.yml")
+
+	h1 := ms.MockedHandler{
+		Overrides:    []*ms.MethodTemplate{},
+		Autoload:     true,
+		AutoloadFile: responses,
+	}
+	h2 := ms.MockedHandler{
+		Overrides:    []*ms.MethodTemplate{},
+		Autoload:     true,
+		AutoloadFile: responses,
+	}
+
+	require.NoError(t, os.Setenv("NODE1_URL", node1.URL()))
+	require.NoError(t, os.Setenv("NODE2_URL", node2.URL()))
+
+	node1.SetHandler(http.HandlerFunc(h1.Handler))
+	node2.SetHandler(http.HandlerFunc(h2.Handler))
+
+	config := ReadConfig("consensus_espresso")
+	svr, shutdown, err := proxyd.Start(config)
+	require.NoError(t, err)
+
+	client := NewProxydClient("http://127.0.0.1:8545")
+
+	bg := svr.BackendGroups["node"]
+	require.NotNil(t, bg)
+	require.NotNil(t, bg.Consensus)
+	require.Equal(t, 2, len(bg.Backends))
+
+	nodes := map[string]nodeContext{
+		"node1": {
+			mockBackend: node1,
+			backend:     bg.Backends[0],
+			handler:     &h1,
+		},
+		"node2": {
+			mockBackend: node2,
+			backend:     bg.Backends[1],
+			handler:     &h2,
+		},
+	}
+
+	return nodes, bg, client, shutdown
+}
+
+func TestConsensusEspresso(t *testing.T) {
+	nodes, bg, client, shutdown := setupEspresso(t)
+	defer nodes["node1"].mockBackend.Close()
+	defer nodes["node2"].mockBackend.Close()
+	defer shutdown()
+
+	ctx := context.Background()
+
+	update := func() {
+		for _, be := range bg.Backends {
+			bg.Consensus.UpdateBackend(ctx, be)
+		}
+		bg.Consensus.UpdateBackendGroupConsensus(ctx)
+	}
+
+	reset := func() {
+		for _, node := range nodes {
+			node.handler.ResetOverrides()
+			node.mockBackend.Reset()
+			node.backend.ClearSlidingWindows()
+		}
+		bg.Consensus.ClearListeners()
+		bg.Consensus.Reset()
+	}
+
+	override := func(node string, method string, block string, response string) {
+		if _, ok := nodes[node]; !ok {
+			t.Fatalf("node %s does not exist in the nodes map", node)
+		}
+		nodes[node].handler.AddOverride(&ms.MethodTemplate{
+			Method:   method,
+			Block:    block,
+			Response: response,
+		})
+	}
+
+	overrideBlock := func(node string, blockRequest string, blockResponse string) {
+		override(node,
+			"eth_getBlockByNumber",
+			blockRequest,
+			buildResponse(map[string]string{
+				"number": blockResponse,
+				"hash":   "hash_" + blockResponse,
+			}))
+	}
+
+	t.Run("initial espresso consensus", func(t *testing.T) {
+		reset()
+
+		require.Equal(t, "0x0", bg.Consensus.GetEspressoBlockNumber().String())
+
+		update()
+
+		// both nodes default to espresso block 0xa0; standard blocks should also resolve
+		require.Equal(t, "0xa0", bg.Consensus.GetEspressoBlockNumber().String())
+		require.Equal(t, "0x101", bg.Consensus.GetLatestBlockNumber().String())
+	})
+
+	t.Run("use lowest espresso block across backends", func(t *testing.T) {
+		reset()
+
+		// node2 reports a higher espresso block than node1's default 0xa0
+		overrideBlock("node2", "espresso", "0xb0")
+		update()
+
+		// consensus picks the minimum across healthy backends
+		require.Equal(t, "0xa0", bg.Consensus.GetEspressoBlockNumber().String())
+	})
+
+	t.Run("espresso block advances when all nodes advance", func(t *testing.T) {
+		reset()
+		update()
+		require.Equal(t, "0xa0", bg.Consensus.GetEspressoBlockNumber().String())
+
+		overrideBlock("node1", "espresso", "0xb0")
+		overrideBlock("node2", "espresso", "0xb0")
+		update()
+
+		require.Equal(t, "0xb0", bg.Consensus.GetEspressoBlockNumber().String())
+	})
+
+	t.Run("espresso block does not go backward", func(t *testing.T) {
+		reset()
+
+		overrideBlock("node1", "espresso", "0xd0")
+		overrideBlock("node2", "espresso", "0xd0")
+		update()
+		require.Equal(t, "0xd0", bg.Consensus.GetEspressoBlockNumber().String())
+
+		// both nodes report a lower espresso block (e.g. after a proxy restart)
+		// 0x90 = 144, 0xd0 = 208
+		overrideBlock("node1", "espresso", "0x90")
+		overrideBlock("node2", "espresso", "0x90")
+		update()
+
+		// monotonicity guarantee: espresso block must not regress
+		require.Equal(t, "0xd0", bg.Consensus.GetEspressoBlockNumber().String())
+	})
+
+	t.Run("rewrite eth_getBlockByNumber with espresso tag", func(t *testing.T) {
+		reset()
+
+		overrideBlock("node1", "espresso", "0xe0")
+		override("node2", "net_peerCount", "", buildResponse("0x0"))
+		update()
+
+		require.Equal(t, "0xe0", bg.Consensus.GetEspressoBlockNumber().String())
+		require.Equal(t, 1, len(bg.Consensus.GetConsensusGroup()))
+
+		// clear request log so we can inspect only the client's request
+		nodes["node1"].mockBackend.Reset()
+
+		_, statusCode, err := client.SendRPC("eth_getBlockByNumber", []interface{}{"espresso", false})
+		require.NoError(t, err)
+		require.Equal(t, 200, statusCode)
+
+		// make sure the response from proxyd has correct state
+		var reqBody map[string]interface{}
+		err = json.Unmarshal(nodes["node1"].mockBackend.Requests()[0].Body, &reqBody)
+		require.NoError(t, err)
+		require.Equal(t, "0xe0", reqBody["params"].([]interface{})[0])
+	})
+
+	t.Run("batch rewrite with espresso tag", func(t *testing.T) {
+		reset()
+
+		overrideBlock("node1", "espresso", "0xe0")
+		override("node2", "net_peerCount", "", buildResponse("0x0"))
+		update()
+		require.Equal(t, "0xe0", bg.Consensus.GetEspressoBlockNumber().String())
+		nodes["node1"].mockBackend.Reset()
+
+		resRaw, statusCode, err := client.SendBatchRPC(
+			NewRPCReq("1", "eth_getBlockByNumber", []interface{}{"espresso", false}),
+			NewRPCReq("2", "eth_getBlockByNumber", []interface{}{"latest", false}),
+		)
+		require.NoError(t, err)
+		require.Equal(t, 200, statusCode)
+
+		var jsonMap []map[string]interface{}
+		err = json.Unmarshal(resRaw, &jsonMap)
+		require.NoError(t, err)
+		require.Equal(t, 2, len(jsonMap))
+
+		require.Equal(t, "0xe0", jsonMap[0]["result"].(map[string]interface{})["number"])
+		require.Equal(t, "0x101", jsonMap[1]["result"].(map[string]interface{})["number"])
+	})
+
+	t.Run("eth_call with espresso block param", func(t *testing.T) {
+		reset()
+
+		overrideBlock("node1", "espresso", "0xe0")
+		override("node2", "net_peerCount", "", buildResponse("0x0"))
+		update()
+		require.Equal(t, "0xe0", bg.Consensus.GetEspressoBlockNumber().String())
+		nodes["node1"].mockBackend.Reset()
+
+		_, statusCode, err := client.SendRPC("eth_call", []interface{}{map[string]string{}, "espresso"})
+		require.NoError(t, err)
+		require.Equal(t, 200, statusCode)
+
+		var reqBody map[string]interface{}
+		err = json.Unmarshal(nodes["node1"].mockBackend.Requests()[0].Body, &reqBody)
+		require.NoError(t, err)
+		require.Equal(t, "0xe0", reqBody["params"].([]interface{})[1])
+	})
+
+	t.Run("non-espresso tag is unaffected by espresso config", func(t *testing.T) {
+		reset()
+
+		override("node2", "net_peerCount", "", buildResponse("0x0"))
+		update()
+		nodes["node1"].mockBackend.Reset()
+
+		_, statusCode, err := client.SendRPC("eth_getBlockByNumber", []interface{}{"latest", false})
+		require.NoError(t, err)
+		require.Equal(t, 200, statusCode)
+
+		var reqBody map[string]interface{}
+		err = json.Unmarshal(nodes["node1"].mockBackend.Requests()[0].Body, &reqBody)
+		require.NoError(t, err)
+		// "latest" rewrites to the consensus latest block, not the espresso block
+		require.Equal(t, "0x101", reqBody["params"].([]interface{})[0])
+	})
+}

--- a/proxyd/integration_tests/testdata/consensus_espresso.toml
+++ b/proxyd/integration_tests/testdata/consensus_espresso.toml
@@ -1,0 +1,32 @@
+[server]
+
+rpc_port = 8545
+
+[backend]
+response_timeout_seconds = 1
+max_degraded_latency_threshold = "30ms"
+
+[backends]
+[backends.node1]
+rpc_url = "$NODE1_URL"
+
+[backends.node2]
+rpc_url = "$NODE2_URL"
+
+[backend_groups]
+[backend_groups.node]
+backends = ["node1", "node2"]
+routing_strategy = "consensus_aware"
+consensus_handler = "noop" # allow more control over the consensus poller for tests
+consensus_ban_period = "1m"
+consensus_max_update_threshold = "2m"
+consensus_max_block_lag = 8
+consensus_min_peer_count = 4
+consensus_espresso_tag = "espresso"
+
+[rpc_method_mappings]
+eth_call = "node"
+eth_chainId = "node"
+eth_blockNumber = "node"
+eth_getBlockByNumber = "node"
+consensus_getReceipts = "node"

--- a/proxyd/integration_tests/testdata/consensus_espresso_responses.yml
+++ b/proxyd/integration_tests/testdata/consensus_espresso_responses.yml
@@ -1,0 +1,127 @@
+- method: eth_call
+  response: >
+    {
+      "jsonrpc": "2.0",
+      "id": 67,
+      "result": "0x"
+    }
+- method: eth_chainId
+  response: >
+    {
+      "jsonrpc": "2.0",
+      "id": 67,
+      "result": "hello"
+    }
+- method: net_peerCount
+  response: >
+    {
+      "jsonrpc": "2.0",
+      "id": 67,
+      "result": "0x10"
+    }
+- method: eth_syncing
+  response: >
+    {
+      "jsonrpc": "2.0",
+      "id": 67,
+      "result": false
+    }
+- method: eth_getBlockByNumber
+  block: latest
+  response: >
+    {
+      "jsonrpc": "2.0",
+      "id": 67,
+      "result": {
+        "hash": "hash_0x101",
+        "number": "0x101"
+      }
+    }
+- method: eth_getBlockByNumber
+  block: safe
+  response: >
+    {
+      "jsonrpc": "2.0",
+      "id": 67,
+      "result": {
+        "hash": "hash_0xe1",
+        "number": "0xe1"
+      }
+    }
+- method: eth_getBlockByNumber
+  block: finalized
+  response: >
+    {
+      "jsonrpc": "2.0",
+      "id": 67,
+      "result": {
+        "hash": "hash_0xc1",
+        "number": "0xc1"
+      }
+    }
+- method: eth_getBlockByNumber
+  block: espresso
+  response: >
+    {
+      "jsonrpc": "2.0",
+      "id": 67,
+      "result": {
+        "hash": "hash_0xa0",
+        "number": "0xa0"
+      }
+    }
+- method: eth_getBlockByNumber
+  block: 0x101
+  response: >
+    {
+      "jsonrpc": "2.0",
+      "id": 67,
+      "result": {
+        "hash": "hash_0x101",
+        "number": "0x101"
+      }
+    }
+- method: eth_getBlockByNumber
+  block: 0xa0
+  response: >
+    {
+      "jsonrpc": "2.0",
+      "id": 67,
+      "result": {
+        "hash": "hash_0xa0",
+        "number": "0xa0"
+      }
+    }
+- method: eth_getBlockByNumber
+  block: 0xe0
+  response: >
+    {
+      "jsonrpc": "2.0",
+      "id": 67,
+      "result": {
+        "hash": "hash_0xe0",
+        "number": "0xe0"
+      }
+    }
+- method: eth_getBlockByNumber
+  block: 0xe1
+  response: >
+    {
+      "jsonrpc": "2.0",
+      "id": 67,
+      "result": {
+        "hash": "hash_0xe1",
+        "number": "0xe1"
+      }
+    }
+- method: eth_getBlockByNumber
+  block: 0xc1
+  response: >
+    {
+      "jsonrpc": "2.0",
+      "id": 67,
+      "result": {
+        "hash": "hash_0xc1",
+        "number": "0xc1"
+      }
+    }

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -441,6 +441,9 @@ func Start(config *Config) (*Server, func(), error) {
 			if bgcfg.ConsensusPollerInterval > 0 {
 				copts = append(copts, WithPollerInterval(time.Duration(bgcfg.ConsensusPollerInterval)))
 			}
+			if bgcfg.ConsensusEspressoTag != "" {
+				copts = append(copts, WithEspressoTag(bgcfg.ConsensusEspressoTag))
+			}
 
 			for _, be := range bgcfg.Backends {
 				if fallback, ok := bg.FallbackBackends[be]; !ok {

--- a/proxyd/rewriter.go
+++ b/proxyd/rewriter.go
@@ -14,6 +14,8 @@ type RewriteContext struct {
 	safe          hexutil.Uint64
 	finalized     hexutil.Uint64
 	maxBlockRange uint64
+	espressoTag   string
+	espresso      hexutil.Uint64
 }
 
 type RewriteResult uint8
@@ -293,6 +295,13 @@ func remarshalBlockNumberOrHash(current interface{}) (*rpc.BlockNumberOrHash, er
 }
 
 func rewriteTag(rctx RewriteContext, current string) (string, bool, error) {
+	if rctx.espressoTag != "" && current == rctx.espressoTag {
+		if rctx.espresso > 0 {
+			return rctx.espresso.String(), true, nil
+		}
+		return current, false, nil
+	}
+
 	bnh, err := remarshalBlockNumberOrHash(current)
 	if err != nil {
 		return "", false, err


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Support in proxyd for the espresso tag. This will poll the registered back-ends (espresso proxy in this case) and get the latest espresso finalized block. To use it in the proxyd.toml you can register the tag like so:
```
consensus_espresso_tag = "espresso"
```
It will take the minimum finalized block of the three, and not move backwards (in the case of restarts).

You can see e2e integration tests in our espresso-proxy repository found in this pr
https://github.com/EspressoSystems/espresso-rollup-node-proxy/pull/38

and if you checkout main you can run to it in action:
`docker compose -f ./espresso_e2e/op/docker-compose.proxyd.yml up -d`
**Tests**

Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.

**Additional context**

Add any other context about the problem you're solving.

**Metadata**

- Fixes #[Link to Issue]
