### PR TITLE
proxyd: block addresses and cap range/count in eth_getLogs

### DIFF
--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -209,6 +209,17 @@ type SenderRateLimitConfig struct {
 	AllowedChainIds []*big.Int `toml:"allowed_chain_ids"`
 }
 
+// EthGetLogsConfig configures address blocking and range/count limits for
+// eth_getLogs requests. Queries targeting a blocked address are served an empty
+// result; queries exceeding max_block_range or max_address_count are rejected.
+// max_block_range and max_address_count default to 1000 and 5 when unset.
+type EthGetLogsConfig struct {
+	BlockedAddresses []string `toml:"blocked_addresses"`
+	MaxBlockRange    uint64   `toml:"max_block_range"`
+	MaxAddressCount  int      `toml:"max_address_count"`
+	ErrorMessage     string   `toml:"error_message"`
+}
+
 type Config struct {
 	WSBackendGroup        string                `toml:"ws_backend_group"`
 	Server                ServerConfig          `toml:"server"`
@@ -228,6 +239,7 @@ type Config struct {
 	SenderRateLimit       SenderRateLimitConfig `toml:"sender_rate_limit"`
 	SanctionedAddresses   []string              `toml:"sanctioned_addresses"`
 	WatchedAddresses      []string              `toml:"watched_addresses"`
+	EthGetLogs            EthGetLogsConfig      `toml:"eth_get_logs"`
 }
 
 func ReadFromEnvOrConfig(value string) (string, error) {

--- a/proxyd/eth_get_logs.go
+++ b/proxyd/eth_get_logs.go
@@ -1,0 +1,229 @@
+package proxyd
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+const (
+	defaultEthGetLogsMaxBlockRange   = 1000
+	defaultEthGetLogsMaxAddressCount = 5
+	defaultEthGetLogsErrorMessage    = "query exceeds range, retry smaller"
+)
+
+// reasons recorded on the eth_get_logs_policy_total metric.
+const (
+	ethGetLogsReasonBlockedAddress       = "blocked_address"
+	ethGetLogsReasonAddressCountExceeded = "address_count_exceeded"
+	ethGetLogsReasonRangeExceeded        = "range_exceeded"
+)
+
+// ethGetLogsLimits holds the resolved policy applied to eth_getLogs requests:
+// a blocklist of addresses (served an empty result) and caps on the block range
+// and number of addresses per query (rejected with an error).
+type ethGetLogsLimits struct {
+	blockedAddresses map[common.Address]struct{}
+	maxBlockRange    uint64
+	maxAddressCount  int
+	errorMessage     string
+}
+
+// newEthGetLogsLimits builds the runtime policy from config, validating blocked
+// addresses and applying defaults for any unset limit.
+func newEthGetLogsLimits(cfg EthGetLogsConfig) ethGetLogsLimits {
+	blocked := make(map[common.Address]struct{}, len(cfg.BlockedAddresses))
+	for _, addr := range cfg.BlockedAddresses {
+		if !common.IsHexAddress(addr) {
+			log.Warn("invalid eth_getLogs blocked address", "address", addr)
+			continue
+		}
+		blocked[common.HexToAddress(addr)] = struct{}{}
+		log.Info("blocking eth_getLogs for address", "address", common.HexToAddress(addr).Hex())
+	}
+
+	lim := ethGetLogsLimits{
+		blockedAddresses: blocked,
+		maxBlockRange:    cfg.MaxBlockRange,
+		maxAddressCount:  cfg.MaxAddressCount,
+		errorMessage:     cfg.ErrorMessage,
+	}
+	if lim.maxBlockRange == 0 {
+		lim.maxBlockRange = defaultEthGetLogsMaxBlockRange
+	}
+	if lim.maxAddressCount == 0 {
+		lim.maxAddressCount = defaultEthGetLogsMaxAddressCount
+	}
+	if lim.errorMessage == "" {
+		lim.errorMessage = defaultEthGetLogsErrorMessage
+	}
+	return lim
+}
+
+// getLogsFilter holds the parts of an eth_getLogs filter object we care about.
+type getLogsFilter struct {
+	addresses []string
+	fromBlock string
+	toBlock   string
+	blockHash string
+}
+
+// parseGetLogsFilter extracts the address list and block bounds from eth_getLogs
+// params. ok is false when the params are absent or malformed, in which case the
+// caller should forward the request and let normal validation/the backend handle it.
+func parseGetLogsFilter(params json.RawMessage) (*getLogsFilter, bool) {
+	var arr []json.RawMessage
+	if err := json.Unmarshal(params, &arr); err != nil || len(arr) == 0 {
+		return nil, false
+	}
+
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(arr[0], &obj); err != nil {
+		return nil, false
+	}
+
+	f := &getLogsFilter{
+		fromBlock: stringField(obj, "fromBlock"),
+		toBlock:   stringField(obj, "toBlock"),
+		blockHash: stringField(obj, "blockHash"),
+	}
+
+	// The address field is either a single string or an array of strings.
+	if raw, ok := obj["address"]; ok {
+		var single string
+		if err := json.Unmarshal(raw, &single); err == nil {
+			if single != "" {
+				f.addresses = []string{single}
+			}
+		} else {
+			var many []string
+			if err := json.Unmarshal(raw, &many); err == nil {
+				f.addresses = many
+			}
+			// If neither shape matches, leave addresses empty: a malformed
+			// address can't match the blocklist and shouldn't be counted.
+		}
+	}
+
+	return f, true
+}
+
+func stringField(obj map[string]json.RawMessage, key string) string {
+	raw, ok := obj[key]
+	if !ok {
+		return ""
+	}
+	var s string
+	_ = json.Unmarshal(raw, &s)
+	return s
+}
+
+// anyBlocked reports whether any address in the query is in the blocklist.
+// Matching is case-insensitive via common.HexToAddress; invalid hex is ignored.
+func anyBlocked(addrs []string, blocked map[common.Address]struct{}) bool {
+	for _, a := range addrs {
+		if !common.IsHexAddress(a) {
+			continue
+		}
+		if _, ok := blocked[common.HexToAddress(a)]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// blockSpan computes toBlock-fromBlock for the filter. ok is false when a bound
+// can't be resolved to a number (e.g. a tag requiring the chain head when the
+// head is unknown, or an inverted range), in which case the range isn't enforced.
+func blockSpan(f *getLogsFilter, head uint64, headKnown bool) (uint64, bool) {
+	from, ok := resolveLogBlock(f.fromBlock, head, headKnown)
+	if !ok {
+		return 0, false
+	}
+	to, ok := resolveLogBlock(f.toBlock, head, headKnown)
+	if !ok {
+		return 0, false
+	}
+	if to < from {
+		return 0, false
+	}
+	return to - from, true
+}
+
+// resolveLogBlock turns a fromBlock/toBlock value into a concrete block number.
+// An empty value defaults to "latest" (the eth_getLogs default for both bounds).
+// ok is false when the value needs the chain head but it isn't known, or when it
+// isn't a recognizable tag or hex quantity.
+func resolveLogBlock(tag string, head uint64, headKnown bool) (uint64, bool) {
+	switch tag {
+	case "", "latest", "safe", "finalized":
+		return head, headKnown
+	case "pending":
+		return head + 1, headKnown
+	case "earliest":
+		return 0, true
+	default:
+		n, err := hexutil.DecodeUint64(tag)
+		if err != nil {
+			return 0, false
+		}
+		return n, true
+	}
+}
+
+// applyEthGetLogsPolicy enforces the eth_getLogs blocklist and range/count caps.
+// It returns a non-nil *RPCRes to serve directly (empty result for a blocked
+// address), a non-nil *RPCErr to reject the request, or (nil, nil) to forward it.
+func (s *Server) applyEthGetLogsPolicy(ctx context.Context, req *RPCReq, group string) (*RPCRes, *RPCErr) {
+	lim := s.ethGetLogs
+
+	f, ok := parseGetLogsFilter(req.Params)
+	if !ok {
+		return nil, nil
+	}
+
+	// Blocked address -> serve an empty result without hitting a backend.
+	if len(lim.blockedAddresses) > 0 && anyBlocked(f.addresses, lim.blockedAddresses) {
+		log.Info("blocked eth_getLogs request for blocked address", "req_id", GetReqID(ctx))
+		RecordEthGetLogsPolicy(ethGetLogsReasonBlockedAddress)
+		RecordRPCForward(ctx, BackendProxyd, "eth_getLogs", RPCRequestSourceHTTP)
+		return NewRPCRes(req.ID, emptyArrayResponse), nil
+	}
+
+	// Too many addresses in a single query.
+	if lim.maxAddressCount > 0 && len(f.addresses) > lim.maxAddressCount {
+		log.Info("eth_getLogs address count exceeds limit",
+			"count", len(f.addresses), "limit", lim.maxAddressCount, "req_id", GetReqID(ctx))
+		RecordEthGetLogsPolicy(ethGetLogsReasonAddressCountExceeded)
+		return nil, ErrInvalidParams(lim.errorMessage)
+	}
+
+	// Block range too large. A blockHash query targets a single block, so it has
+	// no range to cap.
+	if lim.maxBlockRange > 0 && f.blockHash == "" {
+		head, headKnown := s.consensusHead(group)
+		if span, ok := blockSpan(f, head, headKnown); ok && span > lim.maxBlockRange {
+			log.Info("eth_getLogs block range exceeds limit",
+				"span", span, "limit", lim.maxBlockRange, "req_id", GetReqID(ctx))
+			RecordEthGetLogsPolicy(ethGetLogsReasonRangeExceeded)
+			return nil, ErrInvalidParams(lim.errorMessage)
+		}
+	}
+
+	return nil, nil
+}
+
+// consensusHead returns the latest agreed block number for the backend group
+// routing this method, when that group is consensus-aware. headKnown is false
+// when there is no head available to resolve block tags against.
+func (s *Server) consensusHead(group string) (head uint64, headKnown bool) {
+	bg, ok := s.BackendGroups[group]
+	if !ok || bg == nil || bg.Consensus == nil {
+		return 0, false
+	}
+	head = uint64(bg.Consensus.GetLatestBlockNumber())
+	return head, head > 0
+}

--- a/proxyd/eth_get_logs.go
+++ b/proxyd/eth_get_logs.go
@@ -135,15 +135,25 @@ func anyBlocked(addrs []string, blocked map[common.Address]struct{}) bool {
 	return false
 }
 
+// consensusHeads holds the latest/safe/finalized agreed block numbers used to
+// resolve eth_getLogs block tags. known is false when no head is available (the
+// group isn't consensus-aware, or hasn't agreed on a head yet).
+type consensusHeads struct {
+	latest    uint64
+	safe      uint64
+	finalized uint64
+	known     bool
+}
+
 // blockSpan computes toBlock-fromBlock for the filter. ok is false when a bound
-// can't be resolved to a number (e.g. a tag requiring the chain head when the
-// head is unknown, or an inverted range), in which case the range isn't enforced.
-func blockSpan(f *getLogsFilter, head uint64, headKnown bool) (uint64, bool) {
-	from, ok := resolveLogBlock(f.fromBlock, head, headKnown)
+// can't be resolved to a number (e.g. a tag requiring a chain head that isn't
+// known, or an inverted range), in which case the range isn't enforced.
+func blockSpan(f *getLogsFilter, heads consensusHeads) (uint64, bool) {
+	from, ok := resolveLogBlock(f.fromBlock, heads)
 	if !ok {
 		return 0, false
 	}
-	to, ok := resolveLogBlock(f.toBlock, head, headKnown)
+	to, ok := resolveLogBlock(f.toBlock, heads)
 	if !ok {
 		return 0, false
 	}
@@ -155,14 +165,20 @@ func blockSpan(f *getLogsFilter, head uint64, headKnown bool) (uint64, bool) {
 
 // resolveLogBlock turns a fromBlock/toBlock value into a concrete block number.
 // An empty value defaults to "latest" (the eth_getLogs default for both bounds).
-// ok is false when the value needs the chain head but it isn't known, or when it
-// isn't a recognizable tag or hex quantity.
-func resolveLogBlock(tag string, head uint64, headKnown bool) (uint64, bool) {
+// safe/finalized resolve against their own consensus heads, matching the tag
+// rewriting the consensus group applies before forwarding, so a finalized-anchored
+// range isn't measured against the (higher) latest head. ok is false when the
+// value needs a head that isn't known, or isn't a recognizable tag or hex quantity.
+func resolveLogBlock(tag string, heads consensusHeads) (uint64, bool) {
 	switch tag {
-	case "", "latest", "safe", "finalized":
-		return head, headKnown
+	case "", "latest":
+		return heads.latest, heads.known
 	case "pending":
-		return head + 1, headKnown
+		return heads.latest + 1, heads.known
+	case "safe":
+		return heads.safe, heads.known && heads.safe > 0
+	case "finalized":
+		return heads.finalized, heads.known && heads.finalized > 0
 	case "earliest":
 		return 0, true
 	default:
@@ -204,8 +220,7 @@ func (s *Server) applyEthGetLogsPolicy(ctx context.Context, req *RPCReq, group s
 	// Block range too large. A blockHash query targets a single block, so it has
 	// no range to cap.
 	if lim.maxBlockRange > 0 && f.blockHash == "" {
-		head, headKnown := s.consensusHead(group)
-		if span, ok := blockSpan(f, head, headKnown); ok && span > lim.maxBlockRange {
+		if span, ok := blockSpan(f, s.headsForGroup(group)); ok && span > lim.maxBlockRange {
 			log.Info("eth_getLogs block range exceeds limit",
 				"span", span, "limit", lim.maxBlockRange, "req_id", GetReqID(ctx))
 			RecordEthGetLogsPolicy(ethGetLogsReasonRangeExceeded)
@@ -216,14 +231,23 @@ func (s *Server) applyEthGetLogsPolicy(ctx context.Context, req *RPCReq, group s
 	return nil, nil
 }
 
-// consensusHead returns the latest agreed block number for the backend group
-// routing this method, when that group is consensus-aware. headKnown is false
-// when there is no head available to resolve block tags against.
-func (s *Server) consensusHead(group string) (head uint64, headKnown bool) {
+// headsForGroup returns the latest/safe/finalized agreed block numbers for the
+// backend group routing this method. The result has known=false when the group
+// isn't consensus-aware or hasn't agreed on a head yet, so block tags are left
+// unresolved (and the range simply not enforced) rather than guessed.
+func (s *Server) headsForGroup(group string) consensusHeads {
 	bg, ok := s.BackendGroups[group]
 	if !ok || bg == nil || bg.Consensus == nil {
-		return 0, false
+		return consensusHeads{}
 	}
-	head = uint64(bg.Consensus.GetLatestBlockNumber())
-	return head, head > 0
+	latest := uint64(bg.Consensus.GetLatestBlockNumber())
+	if latest == 0 {
+		return consensusHeads{}
+	}
+	return consensusHeads{
+		latest:    latest,
+		safe:      uint64(bg.Consensus.GetSafeBlockNumber()),
+		finalized: uint64(bg.Consensus.GetFinalizedBlockNumber()),
+		known:     true,
+	}
 }

--- a/proxyd/eth_get_logs_test.go
+++ b/proxyd/eth_get_logs_test.go
@@ -1,0 +1,202 @@
+package proxyd
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	blockedAddr = "0x2ca1bf1a40e2b77608345eeb5dea41cdc071d43c"
+	otherAddr   = "0x1111111111111111111111111111111111111111"
+)
+
+func getLogsReq(t *testing.T, filter map[string]interface{}) *RPCReq {
+	t.Helper()
+	params, err := json.Marshal([]interface{}{filter})
+	require.NoError(t, err)
+	return &RPCReq{Method: "eth_getLogs", Params: params, ID: json.RawMessage(`1`)}
+}
+
+func TestParseGetLogsFilter(t *testing.T) {
+	tests := []struct {
+		name      string
+		params    string
+		wantOK    bool
+		wantAddrs []string
+		wantFrom  string
+		wantTo    string
+		wantHash  string
+	}{
+		{name: "single address string", params: `[{"address":"` + blockedAddr + `","fromBlock":"0x1","toBlock":"0x2"}]`, wantOK: true, wantAddrs: []string{blockedAddr}, wantFrom: "0x1", wantTo: "0x2"},
+		{name: "address array", params: `[{"address":["` + blockedAddr + `","` + otherAddr + `"]}]`, wantOK: true, wantAddrs: []string{blockedAddr, otherAddr}},
+		{name: "no address", params: `[{"fromBlock":"0x1"}]`, wantOK: true, wantAddrs: nil, wantFrom: "0x1"},
+		{name: "blockHash", params: `[{"blockHash":"0xabc"}]`, wantOK: true, wantHash: "0xabc"},
+		{name: "empty address string ignored", params: `[{"address":""}]`, wantOK: true, wantAddrs: nil},
+		{name: "malformed object", params: `["nope"]`, wantOK: false},
+		{name: "empty params", params: `[]`, wantOK: false},
+		{name: "not json", params: `garbage`, wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, ok := parseGetLogsFilter(json.RawMessage(tt.params))
+			require.Equal(t, tt.wantOK, ok)
+			if !tt.wantOK {
+				return
+			}
+			require.Equal(t, tt.wantAddrs, f.addresses)
+			require.Equal(t, tt.wantFrom, f.fromBlock)
+			require.Equal(t, tt.wantTo, f.toBlock)
+			require.Equal(t, tt.wantHash, f.blockHash)
+		})
+	}
+}
+
+func TestAnyBlocked(t *testing.T) {
+	blocked := map[common.Address]struct{}{common.HexToAddress(blockedAddr): {}}
+
+	require.True(t, anyBlocked([]string{blockedAddr}, blocked))
+	require.True(t, anyBlocked([]string{otherAddr, blockedAddr}, blocked))
+	// case-insensitive match
+	require.True(t, anyBlocked([]string{common.HexToAddress(blockedAddr).Hex()}, blocked))
+	require.False(t, anyBlocked([]string{otherAddr}, blocked))
+	require.False(t, anyBlocked(nil, blocked))
+	// invalid hex is ignored, not matched
+	require.False(t, anyBlocked([]string{"not-an-address"}, blocked))
+}
+
+func TestBlockSpan(t *testing.T) {
+	tests := []struct {
+		name      string
+		from, to  string
+		head      uint64
+		headKnown bool
+		wantSpan  uint64
+		wantOK    bool
+	}{
+		{name: "numeric range", from: "0x10", to: "0x20", wantSpan: 0x10, wantOK: true},
+		{name: "earliest to number", from: "earliest", to: "0x64", wantSpan: 100, wantOK: true},
+		{name: "latest with head", from: "0x0", to: "latest", head: 50, headKnown: true, wantSpan: 50, wantOK: true},
+		{name: "latest without head not resolvable", from: "0x0", to: "latest", headKnown: false, wantOK: false},
+		{name: "absent bounds default latest", from: "", to: "", head: 0, headKnown: true, wantSpan: 0, wantOK: true},
+		{name: "pending", from: "0x0", to: "pending", head: 9, headKnown: true, wantSpan: 10, wantOK: true},
+		{name: "inverted range not ok", from: "0x20", to: "0x10", wantOK: false},
+		{name: "unparseable bound not ok", from: "0xzz", to: "0x10", wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &getLogsFilter{fromBlock: tt.from, toBlock: tt.to}
+			span, ok := blockSpan(f, tt.head, tt.headKnown)
+			require.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				require.Equal(t, tt.wantSpan, span)
+			}
+		})
+	}
+}
+
+func TestNewEthGetLogsLimits(t *testing.T) {
+	// defaults applied when unset
+	def := newEthGetLogsLimits(EthGetLogsConfig{})
+	require.Equal(t, uint64(defaultEthGetLogsMaxBlockRange), def.maxBlockRange)
+	require.Equal(t, defaultEthGetLogsMaxAddressCount, def.maxAddressCount)
+	require.Equal(t, defaultEthGetLogsErrorMessage, def.errorMessage)
+	require.Empty(t, def.blockedAddresses)
+
+	// explicit values kept, invalid address discarded
+	lim := newEthGetLogsLimits(EthGetLogsConfig{
+		BlockedAddresses: []string{blockedAddr, "garbage"},
+		MaxBlockRange:    100,
+		MaxAddressCount:  3,
+		ErrorMessage:     "nope",
+	})
+	require.Equal(t, uint64(100), lim.maxBlockRange)
+	require.Equal(t, 3, lim.maxAddressCount)
+	require.Equal(t, "nope", lim.errorMessage)
+	require.Len(t, lim.blockedAddresses, 1)
+	_, ok := lim.blockedAddresses[common.HexToAddress(blockedAddr)]
+	require.True(t, ok)
+}
+
+func TestApplyEthGetLogsPolicy(t *testing.T) {
+	// No BackendGroups -> consensus head unknown, so tag-anchored ranges are
+	// skipped and numeric ranges are checked exactly.
+	s := &Server{ethGetLogs: newEthGetLogsLimits(EthGetLogsConfig{
+		BlockedAddresses: []string{blockedAddr},
+		MaxBlockRange:    5000,
+		MaxAddressCount:  25,
+	})}
+	ctx := context.Background()
+
+	isEmptyArray := func(t *testing.T, res *RPCRes) {
+		t.Helper()
+		raw, ok := res.Result.(json.RawMessage)
+		require.True(t, ok)
+		require.Equal(t, "[]", string(raw))
+	}
+
+	t.Run("blocked address served empty", func(t *testing.T) {
+		res, rpcErr := s.applyEthGetLogsPolicy(ctx, getLogsReq(t, map[string]interface{}{"address": blockedAddr}), "")
+		require.Nil(t, rpcErr)
+		require.NotNil(t, res)
+		isEmptyArray(t, res)
+	})
+
+	t.Run("blocked address in array served empty", func(t *testing.T) {
+		res, rpcErr := s.applyEthGetLogsPolicy(ctx, getLogsReq(t, map[string]interface{}{"address": []string{otherAddr, blockedAddr}}), "")
+		require.Nil(t, rpcErr)
+		require.NotNil(t, res)
+		isEmptyArray(t, res)
+	})
+
+	t.Run("normal request forwarded", func(t *testing.T) {
+		res, rpcErr := s.applyEthGetLogsPolicy(ctx, getLogsReq(t, map[string]interface{}{"address": otherAddr, "fromBlock": "0x1", "toBlock": "0x2"}), "")
+		require.Nil(t, rpcErr)
+		require.Nil(t, res)
+	})
+
+	t.Run("address count exceeded rejected", func(t *testing.T) {
+		addrs := make([]string, 26)
+		for i := range addrs {
+			addrs[i] = otherAddr
+		}
+		res, rpcErr := s.applyEthGetLogsPolicy(ctx, getLogsReq(t, map[string]interface{}{"address": addrs}), "")
+		require.Nil(t, res)
+		require.NotNil(t, rpcErr)
+		require.Equal(t, defaultEthGetLogsErrorMessage, rpcErr.Message)
+	})
+
+	t.Run("range exceeded rejected", func(t *testing.T) {
+		res, rpcErr := s.applyEthGetLogsPolicy(ctx, getLogsReq(t, map[string]interface{}{"fromBlock": "0x0", "toBlock": "0x1771"}), "") // 6001 blocks
+		require.Nil(t, res)
+		require.NotNil(t, rpcErr)
+		require.Equal(t, defaultEthGetLogsErrorMessage, rpcErr.Message)
+	})
+
+	t.Run("range at limit allowed", func(t *testing.T) {
+		res, rpcErr := s.applyEthGetLogsPolicy(ctx, getLogsReq(t, map[string]interface{}{"fromBlock": "0x0", "toBlock": "0x1388"}), "") // exactly 5000
+		require.Nil(t, res)
+		require.Nil(t, rpcErr)
+	})
+
+	t.Run("blockHash skips range check", func(t *testing.T) {
+		res, rpcErr := s.applyEthGetLogsPolicy(ctx, getLogsReq(t, map[string]interface{}{"blockHash": "0xabc"}), "")
+		require.Nil(t, res)
+		require.Nil(t, rpcErr)
+	})
+
+	t.Run("tag range without head skipped", func(t *testing.T) {
+		res, rpcErr := s.applyEthGetLogsPolicy(ctx, getLogsReq(t, map[string]interface{}{"fromBlock": "earliest", "toBlock": "latest"}), "")
+		require.Nil(t, res)
+		require.Nil(t, rpcErr)
+	})
+
+	t.Run("malformed params forwarded", func(t *testing.T) {
+		res, rpcErr := s.applyEthGetLogsPolicy(ctx, &RPCReq{Method: "eth_getLogs", Params: json.RawMessage(`["nope"]`), ID: json.RawMessage(`1`)}, "")
+		require.Nil(t, res)
+		require.Nil(t, rpcErr)
+	})
+}

--- a/proxyd/eth_get_logs_test.go
+++ b/proxyd/eth_get_logs_test.go
@@ -69,27 +69,34 @@ func TestAnyBlocked(t *testing.T) {
 }
 
 func TestBlockSpan(t *testing.T) {
+	// latest=12000, safe=10000, finalized=9000 mirrors a chain where safe/finalized
+	// lag latest.
+	lagging := consensusHeads{latest: 12000, safe: 10000, finalized: 9000, known: true}
+
 	tests := []struct {
-		name      string
-		from, to  string
-		head      uint64
-		headKnown bool
-		wantSpan  uint64
-		wantOK    bool
+		name     string
+		from, to string
+		heads    consensusHeads
+		wantSpan uint64
+		wantOK   bool
 	}{
 		{name: "numeric range", from: "0x10", to: "0x20", wantSpan: 0x10, wantOK: true},
 		{name: "earliest to number", from: "earliest", to: "0x64", wantSpan: 100, wantOK: true},
-		{name: "latest with head", from: "0x0", to: "latest", head: 50, headKnown: true, wantSpan: 50, wantOK: true},
-		{name: "latest without head not resolvable", from: "0x0", to: "latest", headKnown: false, wantOK: false},
-		{name: "absent bounds default latest", from: "", to: "", head: 0, headKnown: true, wantSpan: 0, wantOK: true},
-		{name: "pending", from: "0x0", to: "pending", head: 9, headKnown: true, wantSpan: 10, wantOK: true},
+		{name: "latest with head", from: "0x0", to: "latest", heads: consensusHeads{latest: 50, known: true}, wantSpan: 50, wantOK: true},
+		{name: "latest without head not resolvable", from: "0x0", to: "latest", wantOK: false},
+		{name: "absent bounds default latest", from: "", to: "", heads: consensusHeads{latest: 0, known: true}, wantSpan: 0, wantOK: true},
+		{name: "pending", from: "0x0", to: "pending", heads: consensusHeads{latest: 9, known: true}, wantSpan: 10, wantOK: true},
+		// finalized/safe resolve against their own heads, not latest.
+		{name: "finalized uses finalized head", from: "0x2000", to: "finalized", heads: lagging, wantSpan: 9000 - 0x2000, wantOK: true},
+		{name: "safe uses safe head", from: "safe", to: "latest", heads: lagging, wantSpan: 2000, wantOK: true},
+		{name: "finalized unknown not resolvable", from: "0x0", to: "finalized", heads: consensusHeads{latest: 100, known: true}, wantOK: false},
 		{name: "inverted range not ok", from: "0x20", to: "0x10", wantOK: false},
 		{name: "unparseable bound not ok", from: "0xzz", to: "0x10", wantOK: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := &getLogsFilter{fromBlock: tt.from, toBlock: tt.to}
-			span, ok := blockSpan(f, tt.head, tt.headKnown)
+			span, ok := blockSpan(f, tt.heads)
 			require.Equal(t, tt.wantOK, ok)
 			if tt.wantOK {
 				require.Equal(t, tt.wantSpan, span)

--- a/proxyd/example.config.toml
+++ b/proxyd/example.config.toml
@@ -132,6 +132,24 @@ secret = "test"
 #   "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",
 # ]
 
+# Address blocking and range/count limits for eth_getLogs requests.
+[eth_get_logs]
+# Queries whose 'address' filter targets one of these addresses are served an
+# empty result ([]) without hitting a backend. Default: none.
+# blocked_addresses = [
+#   "0x2ca1bf1a40e2b77608345eeb5dea41cdc071d43c",
+# ]
+# Reject queries whose block range (toBlock - fromBlock) exceeds this. Tag bounds
+# (latest/earliest/...) are resolved against the consensus head when available.
+# Default: 1000. Set higher to effectively disable.
+# max_block_range = 1000
+# Reject queries with more than this many addresses in the 'address' filter.
+# Default: 5.
+# max_address_count = 5
+# Error message returned when a query exceeds max_block_range or max_address_count.
+# Default: "query exceeds range, retry smaller".
+# error_message = "query exceeds range, retry smaller"
+
 # Mapping of methods to backend groups.
 [rpc_method_mappings]
 eth_call = "main"

--- a/proxyd/integration_tests/multicall_test.go
+++ b/proxyd/integration_tests/multicall_test.go
@@ -116,7 +116,9 @@ func setServerBackend(s *proxyd.Server, nm map[string]nodeContext) *proxyd.Serve
 }
 
 func nodeBackendRequestCount(nodes map[string]nodeContext, node string) int {
-	return len(nodes[node].mockBackend.requests)
+	// Requests() copies under the backend's lock; reading the slice directly
+	// races with the handler goroutines that append to it.
+	return len(nodes[node].mockBackend.Requests())
 }
 
 func TestMulticall(t *testing.T) {
@@ -146,9 +148,16 @@ func TestMulticall(t *testing.T) {
 		require.NoError(t, json.NewDecoder(resp.Body).Decode(rpcRes))
 		require.False(t, rpcRes.IsError())
 
-		require.Equal(t, 1, nodeBackendRequestCount(nodes, "node1"))
-		require.Equal(t, 1, nodeBackendRequestCount(nodes, "node2"))
-		require.Equal(t, 1, nodeBackendRequestCount(nodes, "node3"))
+		// Multicall dispatches to every backend concurrently and can respond as
+		// soon as a winner is found, so the other backends may still be in flight
+		// when the response is written. Wait for all three to record their request
+		// rather than asserting immediately.
+		require.Eventually(t, func() bool {
+			return nodeBackendRequestCount(nodes, "node1") == 1 &&
+				nodeBackendRequestCount(nodes, "node2") == 1 &&
+				nodeBackendRequestCount(nodes, "node3") == 1
+		}, 5*time.Second, 10*time.Millisecond,
+			"each backend should receive exactly one request")
 	})
 
 	t.Run("When all of the backends return non 200, multicall should return 503", func(t *testing.T) {
@@ -181,9 +190,16 @@ func TestMulticall(t *testing.T) {
 		require.Equal(t, proxyd.ErrNoBackends.Code, rpcRes.Error.Code)
 		require.Equal(t, proxyd.ErrNoBackends.Message, rpcRes.Error.Message)
 
-		require.Equal(t, 1, nodeBackendRequestCount(nodes, "node1"))
-		require.Equal(t, 1, nodeBackendRequestCount(nodes, "node2"))
-		require.Equal(t, 1, nodeBackendRequestCount(nodes, "node3"))
+		// Multicall dispatches to every backend concurrently and can respond as
+		// soon as a winner is found, so the other backends may still be in flight
+		// when the response is written. Wait for all three to record their request
+		// rather than asserting immediately.
+		require.Eventually(t, func() bool {
+			return nodeBackendRequestCount(nodes, "node1") == 1 &&
+				nodeBackendRequestCount(nodes, "node2") == 1 &&
+				nodeBackendRequestCount(nodes, "node3") == 1
+		}, 5*time.Second, 10*time.Millisecond,
+			"each backend should receive exactly one request")
 	})
 
 	t.Run("It should return the first 200 response", func(t *testing.T) {
@@ -233,9 +249,16 @@ func TestMulticall(t *testing.T) {
 		require.False(t, rpcRes.IsError())
 
 		wg.Wait()
-		require.Equal(t, 1, nodeBackendRequestCount(nodes, "node1"))
-		require.Equal(t, 1, nodeBackendRequestCount(nodes, "node2"))
-		require.Equal(t, 1, nodeBackendRequestCount(nodes, "node3"))
+		// Multicall dispatches to every backend concurrently and can respond as
+		// soon as a winner is found, so the other backends may still be in flight
+		// when the response is written. Wait for all three to record their request
+		// rather than asserting immediately.
+		require.Eventually(t, func() bool {
+			return nodeBackendRequestCount(nodes, "node1") == 1 &&
+				nodeBackendRequestCount(nodes, "node2") == 1 &&
+				nodeBackendRequestCount(nodes, "node3") == 1
+		}, 5*time.Second, 10*time.Millisecond,
+			"each backend should receive exactly one request")
 	})
 
 	t.Run("Ensure application level error is returned to caller if its first", func(t *testing.T) {
@@ -284,9 +307,16 @@ func TestMulticall(t *testing.T) {
 
 		wg.Wait()
 
-		require.Equal(t, 1, nodeBackendRequestCount(nodes, "node1"))
-		require.Equal(t, 1, nodeBackendRequestCount(nodes, "node2"))
-		require.Equal(t, 1, nodeBackendRequestCount(nodes, "node3"))
+		// Multicall dispatches to every backend concurrently and can respond as
+		// soon as a winner is found, so the other backends may still be in flight
+		// when the response is written. Wait for all three to record their request
+		// rather than asserting immediately.
+		require.Eventually(t, func() bool {
+			return nodeBackendRequestCount(nodes, "node1") == 1 &&
+				nodeBackendRequestCount(nodes, "node2") == 1 &&
+				nodeBackendRequestCount(nodes, "node3") == 1
+		}, 5*time.Second, 10*time.Millisecond,
+			"each backend should receive exactly one request")
 	})
 
 	t.Run("It should ignore network errors and return a 200 from a slower request", func(t *testing.T) {
@@ -331,9 +361,16 @@ func TestMulticall(t *testing.T) {
 
 		require.Equal(t, resp.Header["X-Served-By"], []string{"node/node1"})
 		wg.Wait()
-		require.Equal(t, 1, nodeBackendRequestCount(nodes, "node1"))
-		require.Equal(t, 1, nodeBackendRequestCount(nodes, "node2"))
-		require.Equal(t, 1, nodeBackendRequestCount(nodes, "node3"))
+		// Multicall dispatches to every backend concurrently and can respond as
+		// soon as a winner is found, so the other backends may still be in flight
+		// when the response is written. Wait for all three to record their request
+		// rather than asserting immediately.
+		require.Eventually(t, func() bool {
+			return nodeBackendRequestCount(nodes, "node1") == 1 &&
+				nodeBackendRequestCount(nodes, "node2") == 1 &&
+				nodeBackendRequestCount(nodes, "node3") == 1
+		}, 5*time.Second, 10*time.Millisecond,
+			"each backend should receive exactly one request")
 	})
 
 	t.Run("When one of the backends times out", func(t *testing.T) {
@@ -375,9 +412,16 @@ func TestMulticall(t *testing.T) {
 		require.False(t, rpcRes.IsError())
 
 		wg.Wait()
-		require.Equal(t, 1, nodeBackendRequestCount(nodes, "node1"))
-		require.Equal(t, 1, nodeBackendRequestCount(nodes, "node2"))
-		require.Equal(t, 1, nodeBackendRequestCount(nodes, "node3"))
+		// Multicall dispatches to every backend concurrently and can respond as
+		// soon as a winner is found, so the other backends may still be in flight
+		// when the response is written. Wait for all three to record their request
+		// rather than asserting immediately.
+		require.Eventually(t, func() bool {
+			return nodeBackendRequestCount(nodes, "node1") == 1 &&
+				nodeBackendRequestCount(nodes, "node2") == 1 &&
+				nodeBackendRequestCount(nodes, "node3") == 1
+		}, 5*time.Second, 10*time.Millisecond,
+			"each backend should receive exactly one request")
 	})
 
 	t.Run("allBackends times out", func(t *testing.T) {
@@ -422,9 +466,16 @@ func TestMulticall(t *testing.T) {
 		require.Equal(t, rpcRes.Error.Code, proxyd.ErrNoBackends.Code)
 
 		wg.Wait()
-		require.Equal(t, 1, nodeBackendRequestCount(nodes, "node1"))
-		require.Equal(t, 1, nodeBackendRequestCount(nodes, "node2"))
-		require.Equal(t, 1, nodeBackendRequestCount(nodes, "node3"))
+		// Multicall dispatches to every backend concurrently and can respond as
+		// soon as a winner is found, so the other backends may still be in flight
+		// when the response is written. Wait for all three to record their request
+		// rather than asserting immediately.
+		require.Eventually(t, func() bool {
+			return nodeBackendRequestCount(nodes, "node1") == 1 &&
+				nodeBackendRequestCount(nodes, "node2") == 1 &&
+				nodeBackendRequestCount(nodes, "node3") == 1
+		}, 5*time.Second, 10*time.Millisecond,
+			"each backend should receive exactly one request")
 	})
 
 	t.Run("Test with many multi-calls in without resetting", func(t *testing.T) {

--- a/proxyd/integration_tests/ws_test.go
+++ b/proxyd/integration_tests/ws_test.go
@@ -218,10 +218,10 @@ func TestWSClientExceedReadLimit(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	closed := false
+	var closed atomic.Bool
 	originalHandler := client.conn.CloseHandler()
 	client.conn.SetCloseHandler(func(code int, text string) error {
-		closed = true
+		closed.Store(true)
 		return originalHandler(code, text)
 	})
 
@@ -236,6 +236,9 @@ func TestWSClientExceedReadLimit(t *testing.T) {
 		[]byte(clientReq),
 	)
 	require.Error(t, err)
-	require.True(t, closed)
-
+	// The close handler fires when the client's read loop processes the server's
+	// close frame, which can lag the WriteMessage error on slow CI runners. Poll
+	// rather than asserting immediately to avoid a timing flake.
+	require.Eventually(t, closed.Load, time.Second, 10*time.Millisecond,
+		"client connection should be closed after exceeding read limit")
 }

--- a/proxyd/metrics.go
+++ b/proxyd/metrics.go
@@ -53,6 +53,14 @@ var (
 		"source",
 	})
 
+	ethGetLogsPolicyTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: MetricsNamespace,
+		Name:      "eth_get_logs_policy_total",
+		Help:      "Count of eth_getLogs requests affected by address blocking or range/count limits, by reason.",
+	}, []string{
+		"reason",
+	})
+
 	rpcBackendHTTPResponseCodesTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: MetricsNamespace,
 		Name:      "rpc_backend_http_response_codes_total",
@@ -492,6 +500,10 @@ func RecordUnserviceableRequest(ctx context.Context, source string) {
 
 func RecordMissingTrieNodeRetry(ctx context.Context, backendGroup string, success bool) {
 	missingTrieNodeRetriesTotal.WithLabelValues(GetAuthCtx(ctx), backendGroup, strconv.FormatBool(success)).Inc()
+}
+
+func RecordEthGetLogsPolicy(reason string) {
+	ethGetLogsPolicyTotal.WithLabelValues(reason).Inc()
 }
 
 func RecordRPCForward(ctx context.Context, backendName, method, source string) {

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -352,6 +352,7 @@ func Start(config *Config) (*Server, func(), error) {
 		redisClient,
 		sanctionedAddressesMap,
 		watchedAddressesMap,
+		newEthGetLogsLimits(config.EthGetLogs),
 	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating server: %w", err)

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -85,6 +85,7 @@ type Server struct {
 	rateLimitHeader        string
 	sanctionedAddresses    map[common.Address]struct{}
 	watchedAddresses       map[common.Address]struct{}
+	ethGetLogs             ethGetLogsLimits
 }
 
 type limiterFunc func(method string) bool
@@ -108,6 +109,7 @@ func NewServer(
 	redisClient *redis.Client,
 	sanctionedAddresses map[common.Address]struct{},
 	watchedAddresses map[common.Address]struct{},
+	ethGetLogs ethGetLogsLimits,
 ) (*Server, error) {
 	if cache == nil {
 		cache = &NoopRPCCache{}
@@ -210,6 +212,7 @@ func NewServer(
 		rateLimitHeader:        rateLimitHeader,
 		sanctionedAddresses:    sanctionedAddresses,
 		watchedAddresses:       watchedAddresses,
+		ethGetLogs:             ethGetLogs,
 	}, nil
 }
 
@@ -647,6 +650,19 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 			if err := s.rateLimitSender(ctx, parsedReq); err != nil {
 				RecordRPCError(ctx, BackendProxyd, parsedReq.Method, err)
 				responses[i] = NewRPCErrorRes(parsedReq.ID, err)
+				continue
+			}
+		}
+
+		// Apply eth_getLogs address blocking and range/count limits. A blocked
+		// address is served an empty result; an over-limit query is rejected.
+		if parsedReq.Method == "eth_getLogs" {
+			if res, rpcErr := s.applyEthGetLogsPolicy(ctx, parsedReq, group); rpcErr != nil {
+				RecordRPCError(ctx, BackendProxyd, parsedReq.Method, rpcErr)
+				responses[i] = NewRPCErrorRes(parsedReq.ID, rpcErr)
+				continue
+			} else if res != nil {
+				responses[i] = res
 				continue
 			}
 		}


### PR DESCRIPTION
## Summary

Adds a new `[eth_get_logs]` config section that enforces three front-door policies on `eth_getLogs` requests (handled in `handleBatchRPC`, so both standalone and batched requests are covered per-element — a bad batch element is rejected/emptied while its siblings forward normally).

1. **Address blocklist** (`blocked_addresses`) — a query whose `address` filter targets a blocked address is served an empty result `[]` directly, without hitting a backend. Motivated by abusive external `eth_getLogs` traffic hammering specific contracts.
2. **Block-range cap** (`max_block_range`, default **1000**) — rejects queries whose span (`toBlock - fromBlock`) exceeds the limit. Block tags (`latest`/`earliest`/absent) are resolved against the routed group's consensus head when available; queries that can't be measured (no head on a non-consensus group, or `blockHash` queries) are **skipped** rather than falsely rejected. Numeric ranges are always checked exactly.
3. **Address-count cap** (`max_address_count`, default **5**) — rejects queries with more than N addresses in the `address` filter.

Over-limit queries return a configurable error (`error_message`, default `"query exceeds range, retry smaller"`).

## Config

```toml
[eth_get_logs]
blocked_addresses = ["0x2ca1bf1a40e2b77608345eeb5dea41cdc071d43c"]
max_block_range   = 1000   # default 1000
max_address_count = 5      # default 5
error_message     = "query exceeds range, retry smaller"
```

All keys are optional; the caps default to 1000 / 5 when unset.

## Implementation notes

- New self-contained `proxyd/eth_get_logs.go` with pure, unit-tested logic (`parseGetLogsFilter`, `anyBlocked`, `blockSpan`) plus two thin `Server` methods. Mirrors the existing `sanctioned_addresses` integration pattern (case-insensitive `common.HexToAddress` matching, per-element batch handling, error plumbing).
- New Prometheus counter `proxyd_eth_get_logs_policy_total{reason="blocked_address"|"range_exceeded"|"address_count_exceeded"}` for observability.
- Limit semantics are "max allowed": count `> max` and span `> max` are rejected (the limit value itself passes), matching the existing `rewriteRange` convention.
- HTTP path only, consistent with `sanctioned_addresses` (`eth_getLogs` isn't in the WS whitelist).

## Testing

`go build ./...`, `go vet`, `gofmt` clean; full `proxyd` package test suite passes. New `eth_get_logs_test.go` covers filter parsing (single/array/absent/malformed/blockHash), blocklist matching (incl. case-insensitivity and invalid hex), range/tag resolution (numeric, earliest, latest±head, pending, inverted, blockHash), default application, and the end-to-end policy method.