### PR TITLE
proxyd: include configured limit in eth_getLogs over-limit error message

### DIFF
--- a/proxyd/eth_get_logs.go
+++ b/proxyd/eth_get_logs.go
@@ -3,6 +3,7 @@ package proxyd
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -214,7 +215,8 @@ func (s *Server) applyEthGetLogsPolicy(ctx context.Context, req *RPCReq, group s
 		log.Info("eth_getLogs address count exceeds limit",
 			"count", len(f.addresses), "limit", lim.maxAddressCount, "req_id", GetReqID(ctx))
 		RecordEthGetLogsPolicy(ethGetLogsReasonAddressCountExceeded)
-		return nil, ErrInvalidParams(lim.errorMessage)
+		return nil, ErrInvalidParams(fmt.Sprintf("%s (max %d addresses per query, got %d)",
+			lim.errorMessage, lim.maxAddressCount, len(f.addresses)))
 	}
 
 	// Block range too large. A blockHash query targets a single block, so it has
@@ -224,7 +226,8 @@ func (s *Server) applyEthGetLogsPolicy(ctx context.Context, req *RPCReq, group s
 			log.Info("eth_getLogs block range exceeds limit",
 				"span", span, "limit", lim.maxBlockRange, "req_id", GetReqID(ctx))
 			RecordEthGetLogsPolicy(ethGetLogsReasonRangeExceeded)
-			return nil, ErrInvalidParams(lim.errorMessage)
+			return nil, ErrInvalidParams(fmt.Sprintf("%s (max block range %d, got %d)",
+				lim.errorMessage, lim.maxBlockRange, span))
 		}
 	}
 

--- a/proxyd/eth_get_logs_test.go
+++ b/proxyd/eth_get_logs_test.go
@@ -173,14 +173,18 @@ func TestApplyEthGetLogsPolicy(t *testing.T) {
 		res, rpcErr := s.applyEthGetLogsPolicy(ctx, getLogsReq(t, map[string]interface{}{"address": addrs}), "")
 		require.Nil(t, res)
 		require.NotNil(t, rpcErr)
-		require.Equal(t, defaultEthGetLogsErrorMessage, rpcErr.Message)
+		require.Contains(t, rpcErr.Message, defaultEthGetLogsErrorMessage)
+		require.Contains(t, rpcErr.Message, "25") // configured max address count
+		require.Contains(t, rpcErr.Message, "26") // requested count
 	})
 
 	t.Run("range exceeded rejected", func(t *testing.T) {
 		res, rpcErr := s.applyEthGetLogsPolicy(ctx, getLogsReq(t, map[string]interface{}{"fromBlock": "0x0", "toBlock": "0x1771"}), "") // 6001 blocks
 		require.Nil(t, res)
 		require.NotNil(t, rpcErr)
-		require.Equal(t, defaultEthGetLogsErrorMessage, rpcErr.Message)
+		require.Contains(t, rpcErr.Message, defaultEthGetLogsErrorMessage)
+		require.Contains(t, rpcErr.Message, "5000") // configured max block range
+		require.Contains(t, rpcErr.Message, "6001") // requested span
 	})
 
 	t.Run("range at limit allowed", func(t *testing.T) {

--- a/proxyd/example.config.toml
+++ b/proxyd/example.config.toml
@@ -147,6 +147,8 @@ secret = "test"
 # Default: 5.
 # max_address_count = 5
 # Error message returned when a query exceeds max_block_range or max_address_count.
+# The exceeded limit and the requested value are appended, e.g.
+# "query exceeds range, retry smaller (max block range 1000, got 6001)".
 # Default: "query exceeds range, retry smaller".
 # error_message = "query exceeds range, retry smaller"
 


### PR DESCRIPTION
## Summary

When proxyd rejects an `eth_getLogs` request for exceeding `max_block_range` or `max_address_count`, the error now includes the configured limit and the requested value, so the caller knows the cap and how far over they were:

- Range: `query exceeds range, retry smaller (max block range 1000, got 6001)`
- Address count: `query exceeds range, retry smaller (max 5 addresses per query, got 26)`

The configured `error_message` remains the prefix; the limit/requested detail is appended.

## Changes
- `proxyd/eth_get_logs.go`: append the exceeded limit + requested value to the rejection message (added `fmt` import).
- `proxyd/eth_get_logs_test.go`: assert the message contains the base message, the configured limit, and the requested value.
- `proxyd/example.config.toml`: document that the limit/requested value is appended to `error_message`.

## Notes
Follow-up to #33 (eth_getLogs blocking + range/count limits). `go build`, `go vet`, `gofmt`, and the proxyd package tests pass.

This change was briefly committed directly to `main` (`4710fba`) by mistake and then reverted on `main` (`0c7356b`); this PR re-introduces it through review.