### PR TITLE
proxyd: cap state-read depth (consensus_max_blocks_back); route old eth_getLogs to archive

### DIFF
--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -135,6 +135,11 @@ var (
 		Message:       "address is sanctioned",
 		HTTPErrorCode: 403,
 	}
+	ErrArchiveBackendUnavailable = &RPCErr{
+		Code:          JSONRPCErrorInternal - 22,
+		Message:       "no archive backend available to serve historical eth_getLogs range",
+		HTTPErrorCode: 503,
+	}
 
 	ErrBackendUnexpectedJSONRPC = errors.New("backend returned an unexpected JSON-RPC response")
 
@@ -802,6 +807,18 @@ func (bg *BackendGroup) GetRoutingStrategy() RoutingStrategy {
 	return bg.routingStrategy
 }
 
+// hasArchiveBackend reports whether the group is configured with at least one archive
+// backend (regardless of current health). Used to tell a transient archive outage apart
+// from a deployment that simply runs no archive backends.
+func (bg *BackendGroup) hasArchiveBackend() bool {
+	for _, b := range bg.Backends {
+		if b.archive {
+			return true
+		}
+	}
+	return false
+}
+
 func (bg *BackendGroup) Fallbacks() []*Backend {
 	fallbacks := []*Backend{}
 	for _, a := range bg.Backends {
@@ -850,11 +867,23 @@ func (bg *BackendGroup) Forward(ctx context.Context, rpcReqs []*RPCReq, isBatch 
 
 	// Determine if archive is required
 	archiveRequired := false
+	getLogsArchiveRequired := false
 	for _, req := range rpcReqs {
 		// All debug_* methods require archive nodes
 		if strings.HasPrefix(req.Method, "debug_") {
 			archiveRequired = true
 			break
+		}
+
+		// eth_getLogs carries its block bounds in a filter object (fromBlock/toBlock),
+		// not a positional param, so it can't use blockParamIndex. Route to archive when
+		// its oldest bound is beyond the archive threshold, or when it pins a blockHash.
+		if req.Method == "eth_getLogs" {
+			if bg.Consensus != nil && getLogsRequiresArchive(req, bg.Consensus.GetLatestBlockNumber(), bg.ArchiveBlockThreshold) {
+				archiveRequired = true
+				getLogsArchiveRequired = true
+			}
+			continue
 		}
 
 		idx, ok := blockParamIndex[req.Method]
@@ -898,6 +927,11 @@ func (bg *BackendGroup) Forward(ctx context.Context, rpcReqs []*RPCReq, isBatch 
 		}
 		if len(archiveBackends) > 0 {
 			backends = archiveBackends
+		} else if getLogsArchiveRequired && bg.hasArchiveBackend() {
+			// The group runs archive backends but none are currently healthy. Serving an
+			// old eth_getLogs range from a full node would return a silent empty result for
+			// pruned blocks, so fail loudly instead of best-effort routing to a full node.
+			return nil, "", ErrArchiveBackendUnavailable
 		}
 		rpcArchiveRequestsTotal.Inc()
 	} else if bg.RestrictArchiveNodeTraffic {
@@ -1877,6 +1911,28 @@ func requiresArchiveForBlock(blockParam string, latestBlockNumber hexutil.Uint64
 		}
 	}
 	return false
+}
+
+// getLogsRequiresArchive reports whether an eth_getLogs request must be served by an
+// archive backend: either it pins a blockHash (not bounded by number) or its oldest
+// bound (fromBlock) is far enough behind head to require archive data. fromBlock/toBlock
+// tags are already resolved to block numbers by the request rewriter at this point.
+func getLogsRequiresArchive(req *RPCReq, latestBlockNumber hexutil.Uint64, archiveBlockThreshold uint64) bool {
+	var params []map[string]interface{}
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		// Fail safe: if the bounds can't be parsed, route to archive rather than risk
+		// serving an old (pruned) range from a full node that returns a silent empty set.
+		return true
+	}
+	if len(params) == 0 {
+		return false
+	}
+	filter := params[0]
+	if _, ok := filter["blockHash"]; ok {
+		return true
+	}
+	// fromBlock is the oldest bound; if it requires archive, the whole query does.
+	return requiresArchiveForBlock(extractBlockParameter(filter["fromBlock"]), latestBlockNumber, archiveBlockThreshold)
 }
 
 // receiptMethods maps RPC methods that return receipt arrays.

--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -1794,6 +1794,7 @@ func (bg *BackendGroup) OverwriteConsensusResponses(rpcReqs []*RPCReq, overridde
 		safe:          bg.Consensus.GetSafeBlockNumber(),
 		finalized:     bg.Consensus.GetFinalizedBlockNumber(),
 		maxBlockRange: bg.Consensus.maxBlockRange,
+		maxBlocksBack: bg.Consensus.maxBlocksBack,
 	}
 
 	for i, req := range rpcReqs {
@@ -1811,6 +1812,10 @@ func (bg *BackendGroup) OverwriteConsensusResponses(rpcReqs []*RPCReq, overridde
 			} else if errors.Is(err, ErrRewriteRangeTooLarge) {
 				res.Error = ErrInvalidParams(
 					fmt.Sprintf("block range greater than %d max", rctx.maxBlockRange),
+				)
+			} else if errors.Is(err, ErrRewriteBlockTooOld) {
+				res.Error = ErrInvalidParams(
+					fmt.Sprintf("block is more than %d blocks behind head", rctx.maxBlocksBack),
 				)
 			} else {
 				res.Error = ErrParseErr

--- a/proxyd/backend_test.go
+++ b/proxyd/backend_test.go
@@ -263,6 +263,103 @@ func TestRequiresArchiveForBlock(t *testing.T) {
 	}
 }
 
+func TestGetLogsRequiresArchive(t *testing.T) {
+	latest := hexutil.Uint64(1000)
+
+	tests := []struct {
+		name      string
+		filter    map[string]interface{}
+		latest    hexutil.Uint64
+		threshold uint64
+		expected  bool
+	}{
+		{
+			name:     "no block bounds (defaults to latest)",
+			filter:   map[string]interface{}{"address": "0x123"},
+			latest:   latest,
+			expected: false,
+		},
+		{
+			name:     "recent fromBlock",
+			filter:   map[string]interface{}{"fromBlock": "0x3e0"}, // 992, 8 behind head
+			latest:   latest,
+			expected: false,
+		},
+		{
+			name:     "old fromBlock",
+			filter:   map[string]interface{}{"fromBlock": "0x100"}, // 256, 744 behind head
+			latest:   latest,
+			expected: true,
+		},
+		{
+			name:     "earliest fromBlock",
+			filter:   map[string]interface{}{"fromBlock": "earliest"},
+			latest:   latest,
+			expected: true,
+		},
+		{
+			name:     "latest fromBlock",
+			filter:   map[string]interface{}{"fromBlock": "latest"},
+			latest:   latest,
+			expected: false,
+		},
+		{
+			name:     "blockHash pins archive",
+			filter:   map[string]interface{}{"blockHash": "0xabcdef"},
+			latest:   latest,
+			expected: true,
+		},
+		{
+			// oldest bound governs: old fromBlock requires archive even with a recent toBlock.
+			name:     "old fromBlock with recent toBlock",
+			filter:   map[string]interface{}{"fromBlock": "0x100", "toBlock": "0x3e0"},
+			latest:   latest,
+			expected: true,
+		},
+		{
+			name:      "custom threshold: old fromBlock",
+			filter:    map[string]interface{}{"fromBlock": "0x1f4"}, // 500, 500 behind head
+			latest:    latest,
+			threshold: 500,
+			expected:  true,
+		},
+		{
+			name:      "custom threshold: recent fromBlock",
+			filter:    map[string]interface{}{"fromBlock": "0x3e0"}, // 992
+			latest:    latest,
+			threshold: 500,
+			expected:  false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := &RPCReq{
+				Method: "eth_getLogs",
+				Params: mustMarshalJSON([]map[string]interface{}{test.filter}),
+			}
+			result := getLogsRequiresArchive(req, test.latest, test.threshold)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+
+	t.Run("empty params", func(t *testing.T) {
+		req := &RPCReq{Method: "eth_getLogs", Params: mustMarshalJSON([]map[string]interface{}{})}
+		assert.False(t, getLogsRequiresArchive(req, latest, 0))
+	})
+
+	t.Run("unparseable params fail safe to archive", func(t *testing.T) {
+		req := &RPCReq{Method: "eth_getLogs", Params: json.RawMessage(`{"not":"an array"}`)}
+		assert.True(t, getLogsRequiresArchive(req, latest, 0))
+	})
+}
+
+func TestHasArchiveBackend(t *testing.T) {
+	assert.False(t, (&BackendGroup{}).hasArchiveBackend())
+	assert.False(t, (&BackendGroup{Backends: []*Backend{{archive: false}}}).hasArchiveBackend())
+	assert.True(t, (&BackendGroup{Backends: []*Backend{{archive: false}, {archive: true}}}).hasArchiveBackend())
+}
+
 func TestContainsArchiveRequiredError(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/proxyd/config.go
+++ b/proxyd/config.go
@@ -178,6 +178,7 @@ type BackendGroupConfig struct {
 	ConsensusMaxUpdateThreshold TOMLDuration `toml:"consensus_max_update_threshold"`
 	ConsensusMaxBlockLag        *uint64      `toml:"consensus_max_block_lag"`
 	ConsensusMaxBlockRange      uint64       `toml:"consensus_max_block_range"`
+	ConsensusMaxBlocksBack      uint64       `toml:"consensus_max_blocks_back"`
 	ConsensusMinPeerCount       int          `toml:"consensus_min_peer_count"`
 
 	ConsensusHA                  bool         `toml:"consensus_ha"`

--- a/proxyd/consensus_poller.go
+++ b/proxyd/consensus_poller.go
@@ -39,6 +39,7 @@ type ConsensusPoller struct {
 	maxUpdateThreshold time.Duration
 	maxBlockLag        uint64
 	maxBlockRange      uint64
+	maxBlocksBack      uint64
 	interval           time.Duration
 }
 
@@ -251,6 +252,12 @@ func WithMaxBlockLag(maxBlockLag uint64) ConsensusOpt {
 func WithMaxBlockRange(maxBlockRange uint64) ConsensusOpt {
 	return func(cp *ConsensusPoller) {
 		cp.maxBlockRange = maxBlockRange
+	}
+}
+
+func WithMaxBlocksBack(maxBlocksBack uint64) ConsensusOpt {
+	return func(cp *ConsensusPoller) {
+		cp.maxBlocksBack = maxBlocksBack
 	}
 }
 

--- a/proxyd/example.config.toml
+++ b/proxyd/example.config.toml
@@ -100,6 +100,11 @@ backends = ["infura"]
 # consensus_max_block_lag = 16
 # Maximum block range (for eth_getLogs method), no default
 # consensus_max_block_range = 20000
+# Maximum number of blocks behind head a block-addressed read may target, no default.
+# When set, requests whose block parameter is more than this many blocks behind the
+# latest block are rejected (applies to eth_call, eth_getBalance, eth_getCode,
+# eth_getTransactionCount, eth_getStorageAt, eth_getProof, and eth_getLogs from/toBlock).
+# consensus_max_blocks_back = 100000
 # Minimum peer count, default 3
 # consensus_min_peer_count = 4
 # Restrict archive node traffic to only archive-required requests, default false

--- a/proxyd/example.config.toml
+++ b/proxyd/example.config.toml
@@ -100,21 +100,27 @@ backends = ["infura"]
 # consensus_max_block_lag = 16
 # Maximum block range (for eth_getLogs method), no default
 # consensus_max_block_range = 20000
-# Maximum number of blocks behind head a block-addressed read may target, no default.
-# When set, requests whose block parameter is more than this many blocks behind the
-# latest block are rejected (applies to eth_call, eth_getBalance, eth_getCode,
-# eth_getTransactionCount, eth_getStorageAt, eth_getProof, and eth_getLogs from/toBlock).
+# Maximum number of blocks behind head a block-addressed STATE read may target, no default.
+# When set, requests whose block parameter is more than this many blocks behind the latest
+# block are rejected (applies to eth_call, eth_getBalance, eth_getCode,
+# eth_getTransactionCount, eth_getStorageAt, and eth_getProof). eth_getLogs is exempt: its
+# cost is bounded by block-range width (consensus_max_block_range), not depth, and old
+# ranges are routed to archive backends instead of being rejected.
 # consensus_max_blocks_back = 100000
 # Minimum peer count, default 3
 # consensus_min_peer_count = 4
 # Restrict archive node traffic to only archive-required requests, default false
 # When enabled, archive backends (archive=true) will only receive traffic for:
-# - Requests that explicitly require archive data (old blocks, blockHash queries)
+# - Requests that explicitly require archive data (old blocks, blockHash queries, and
+#   eth_getLogs whose range starts before archive_block_threshold)
 # - Regular requests when no non-archive backends are available (fallback)
 # restrict_archive_node_traffic = true
 # Number of blocks from head beyond which requests are routed to archive backends.
 # Default: 128 (standard full-node state window)
 # archive_block_threshold = 1000000
+# Note: if the group has archive backends configured but none are currently healthy, an
+# eth_getLogs whose range requires archive fails with an explicit error (HTTP 503) rather
+# than being served from a full node, which would silently return [] for pruned blocks.
 
 [backend_groups.alchemy]
 backends = ["alchemy"]

--- a/proxyd/proxyd.go
+++ b/proxyd/proxyd.go
@@ -439,6 +439,9 @@ func Start(config *Config) (*Server, func(), error) {
 			if bgcfg.ConsensusMaxBlockRange > 0 {
 				copts = append(copts, WithMaxBlockRange(bgcfg.ConsensusMaxBlockRange))
 			}
+			if bgcfg.ConsensusMaxBlocksBack > 0 {
+				copts = append(copts, WithMaxBlocksBack(bgcfg.ConsensusMaxBlocksBack))
+			}
 			if bgcfg.ConsensusPollerInterval > 0 {
 				copts = append(copts, WithPollerInterval(time.Duration(bgcfg.ConsensusPollerInterval)))
 			}

--- a/proxyd/rewriter.go
+++ b/proxyd/rewriter.go
@@ -200,6 +200,13 @@ func shouldReturnNullOnOutOfRange(method string) bool {
 }
 
 func rewriteRange(rctx RewriteContext, req *RPCReq, res *RPCRes, pos int) (RewriteResult, error) {
+	// eth_getLogs/eth_newFilter cost scales with block-range width, not with how far
+	// behind head the range sits (receipts are age-independent reads), so the
+	// consensus_max_blocks_back "too far behind head" guard does not apply here. Old
+	// ranges are sent to archive backends by the archive-routing layer instead. The
+	// range-width cap (maxBlockRange) and future-block check below still apply.
+	rctx.maxBlocksBack = 0
+
 	var p []map[string]interface{}
 	err := json.Unmarshal(req.Params, &p)
 	if err != nil {

--- a/proxyd/rewriter.go
+++ b/proxyd/rewriter.go
@@ -14,6 +14,7 @@ type RewriteContext struct {
 	safe          hexutil.Uint64
 	finalized     hexutil.Uint64
 	maxBlockRange uint64
+	maxBlocksBack uint64
 }
 
 type RewriteResult uint8
@@ -35,7 +36,18 @@ const (
 var (
 	ErrRewriteBlockOutOfRange = errors.New("block is out of range")
 	ErrRewriteRangeTooLarge   = errors.New("block range is too large")
+	ErrRewriteBlockTooOld     = errors.New("block is too far behind head")
 )
+
+// blockTooOld reports whether the requested block is further behind the latest
+// block than maxBlocksBack allows. A zero maxBlocksBack disables the check.
+func blockTooOld(rctx RewriteContext, block uint64) bool {
+	if rctx.maxBlocksBack == 0 {
+		return false
+	}
+	latest := uint64(rctx.latest)
+	return latest > block && latest-block > rctx.maxBlocksBack
+}
 
 // RewriteTags modifies the request and the response based on block tags
 func RewriteTags(rctx RewriteContext, req *RPCReq, res *RPCRes, skipEIP1898 bool) (RewriteResult, error) {
@@ -304,8 +316,12 @@ func rewriteTag(rctx RewriteContext, current string) (string, bool, error) {
 	}
 
 	switch *bnh.BlockNumber {
-	case rpc.PendingBlockNumber,
-		rpc.EarliestBlockNumber:
+	case rpc.PendingBlockNumber:
+		return current, false, nil
+	case rpc.EarliestBlockNumber:
+		if blockTooOld(rctx, 0) {
+			return "", false, ErrRewriteBlockTooOld
+		}
 		return current, false, nil
 	case rpc.FinalizedBlockNumber:
 		return rctx.finalized.String(), true, nil
@@ -316,6 +332,9 @@ func rewriteTag(rctx RewriteContext, current string) (string, bool, error) {
 	default:
 		if bnh.BlockNumber.Int64() > int64(rctx.latest) {
 			return "", false, ErrRewriteBlockOutOfRange
+		}
+		if blockTooOld(rctx, uint64(bnh.BlockNumber.Int64())) {
+			return "", false, ErrRewriteBlockTooOld
 		}
 	}
 
@@ -329,8 +348,12 @@ func rewriteTagBlockNumberOrHash(rctx RewriteContext, current *rpc.BlockNumberOr
 	}
 
 	switch *current.BlockNumber {
-	case rpc.PendingBlockNumber,
-		rpc.EarliestBlockNumber:
+	case rpc.PendingBlockNumber:
+		return current, false, nil
+	case rpc.EarliestBlockNumber:
+		if blockTooOld(rctx, 0) {
+			return nil, false, ErrRewriteBlockTooOld
+		}
 		return current, false, nil
 	case rpc.FinalizedBlockNumber:
 		bn := rpc.BlockNumberOrHashWithNumber(rpc.BlockNumber(rctx.finalized))
@@ -344,6 +367,9 @@ func rewriteTagBlockNumberOrHash(rctx RewriteContext, current *rpc.BlockNumberOr
 	default:
 		if current.BlockNumber.Int64() > int64(rctx.latest) {
 			return nil, false, ErrRewriteBlockOutOfRange
+		}
+		if blockTooOld(rctx, uint64(current.BlockNumber.Int64())) {
+			return nil, false, ErrRewriteBlockTooOld
 		}
 	}
 

--- a/proxyd/rewriter_test.go
+++ b/proxyd/rewriter_test.go
@@ -221,6 +221,28 @@ func TestRewriteRequest(t *testing.T) {
 				require.Equal(t, hexutil.Uint64(100).String(), p[0]["toBlock"])
 			},
 		},
+		{
+			// state reads at this depth are rejected (see "eth_getCode too far behind
+			// head"), but getLogs is range-axis, not depth-axis, so it must be allowed.
+			name: "eth_getLogs fromBlock far behind head is not depth-limited",
+			args: args{
+				rctx:        RewriteContext{latest: hexutil.Uint64(100), maxBlocksBack: 30},
+				req:         &RPCReq{Method: "eth_getLogs", Params: mustMarshalJSON([]map[string]interface{}{{"fromBlock": hexutil.Uint64(50).String(), "toBlock": hexutil.Uint64(60).String()}})},
+				res:         nil,
+				skipeip1898: false,
+			},
+			expected: RewriteNone,
+		},
+		{
+			name: "eth_getLogs earliest is not depth-limited",
+			args: args{
+				rctx:        RewriteContext{latest: hexutil.Uint64(100), maxBlocksBack: 30},
+				req:         &RPCReq{Method: "eth_getLogs", Params: mustMarshalJSON([]map[string]interface{}{{"fromBlock": "earliest", "toBlock": hexutil.Uint64(60).String()}})},
+				res:         nil,
+				skipeip1898: false,
+			},
+			expected: RewriteNone,
+		},
 		/* required parameter at pos 0 */
 		{
 			name: "debug_getRawReceipts latest",

--- a/proxyd/rewriter_test.go
+++ b/proxyd/rewriter_test.go
@@ -380,6 +380,38 @@ func TestRewriteRequest(t *testing.T) {
 			expected:    RewriteOverrideError,
 			expectedErr: ErrRewriteBlockOutOfRange,
 		},
+		{
+			name: "eth_getCode too far behind head",
+			args: args{
+				rctx:        RewriteContext{latest: hexutil.Uint64(100), maxBlocksBack: 30},
+				req:         &RPCReq{Method: "eth_getCode", Params: mustMarshalJSON([]string{"0x123", hexutil.Uint64(50).String()})},
+				res:         nil,
+				skipeip1898: false,
+			},
+			expected:    RewriteOverrideError,
+			expectedErr: ErrRewriteBlockTooOld,
+		},
+		{
+			name: "eth_getCode within blocks back",
+			args: args{
+				rctx:        RewriteContext{latest: hexutil.Uint64(100), maxBlocksBack: 30},
+				req:         &RPCReq{Method: "eth_getCode", Params: mustMarshalJSON([]string{"0x123", hexutil.Uint64(80).String()})},
+				res:         nil,
+				skipeip1898: false,
+			},
+			expected: RewriteNone,
+		},
+		{
+			name: "eth_getCode earliest too far behind head",
+			args: args{
+				rctx:        RewriteContext{latest: hexutil.Uint64(100), maxBlocksBack: 30},
+				req:         &RPCReq{Method: "eth_getCode", Params: mustMarshalJSON([]string{"0x123", "earliest"})},
+				res:         nil,
+				skipeip1898: false,
+			},
+			expected:    RewriteOverrideError,
+			expectedErr: ErrRewriteBlockTooOld,
+		},
 		/* default block parameter, at position 2 */
 		{
 			name: "eth_getStorageAt omit block, should add",
@@ -656,6 +688,22 @@ func TestRewriteRequest(t *testing.T) {
 			},
 			expected:    RewriteOverrideError,
 			expectedErr: ErrRewriteBlockOutOfRange,
+		},
+		{
+			name: "eth_getStorageAt using rpc.BlockNumberOrHash too far behind head",
+			args: args{
+				rctx: RewriteContext{latest: hexutil.Uint64(100), maxBlocksBack: 30},
+				req: &RPCReq{Method: "eth_getStorageAt", Params: mustMarshalJSON([]interface{}{
+					"0xae851f927ee40de99aabb7461c00f9622ab91d60",
+					"10",
+					map[string]interface{}{
+						"blockNumber": hexutil.Uint64(50).String(),
+					}})},
+				res:         nil,
+				skipeip1898: false,
+			},
+			expected:    RewriteOverrideError,
+			expectedErr: ErrRewriteBlockTooOld,
 		},
 		// eip1898 disabled
 		{


### PR DESCRIPTION
## What

Adds a per-backend-group config option **`consensus_max_blocks_back`**. When set, any block-addressed **state** read whose block parameter is more than that many blocks behind the consensus *latest* block is rejected before being forwarded to a backend.

This is the historical-**depth** counterpart to the existing `consensus_max_block_range` (which caps `eth_getLogs` **span width**). Where `max_block_range` limits how *wide* a range query is, `max_blocks_back` limits how *deep* into history a point read may reach.

## Why

State reads (`eth_call` and friends) had no lower-bound guard — the only existing block check in `rewriteTag` rejects blocks *above* head (future), never old ones. A request for block 1 when head is 30M sailed straight through to backends, forcing op-reth to reconstruct historical state from changesets (the expensive path that loads/saturates backends). This lets operators cap deep-history reads.

## Coverage (state reads only)

The check lives in the shared `rewriteTag` / `rewriteTagBlockNumberOrHash` path, so one guard covers every block-addressed **state** read:

- `eth_call`, `eth_getBalance`, `eth_getCode`, `eth_getTransactionCount`
- `eth_getStorageAt`, `eth_getProof` (incl. EIP-1898 `BlockNumberOrHash`)

The `earliest` tag is also rejected when out of bounds, so the limit can't be trivially bypassed. `latest`/`safe`/`finalized`/`pending` are unaffected (they resolve at/near head).

## eth_getLogs is intentionally exempt — bounded by range + routed to archive

`eth_getLogs`/`eth_newFilter` cost scales with **block-range width**, not with how far behind head the range sits (receipts are age-independent reads), so the depth cap is the wrong axis for them — applying it would reject cheap, legitimate historical-event queries. So:

- **Exempt from the depth cap** (`rewriteRange` clears `maxBlocksBack`); the range-width cap (`consensus_max_block_range`) and the future-block check still apply.
- **Old ranges route to archive backends** instead: a new `getLogsRequiresArchive` flags archive when the oldest bound (`fromBlock`) is beyond `archive_block_threshold`, or the query pins a `blockHash`. Full nodes prune old receipts and would otherwise silently return `[]` for pruned blocks.
- **Fail loud on archive outage**: if the group runs archive backends but none are currently healthy, an old getLogs returns `ErrArchiveBackendUnavailable` (HTTP 503) rather than silently falling back to a full node. Scoped via `hasArchiveBackend()`, so deployments with no archive backends are unaffected.

## Behavior & safety

- **Unset (zero) disables the depth check** — fully backwards compatible, no behavior change for existing configs.
- Only active in consensus-aware mode (needs `latest` from the consensus poller), same as `max_block_range`.
- Rejected state reads return `ErrInvalidParams` with a message naming the configured limit, e.g. `block is more than 100000 blocks behind head`.

## Interaction with `restrict_archive_node_traffic` / `archive_block_threshold`

These compose into a "Hybrid" posture rather than overlapping:
- `archive_block_threshold` **routes** moderately-old reads to archive backends.
- `consensus_max_blocks_back` **rejects** state reads past an absolute depth.
- `eth_getLogs` is never depth-rejected — routed to archive by the same `archive_block_threshold`.

## Config

```toml
# State reads: reject beyond this depth (no default; unset disables).
# consensus_max_blocks_back = 100000
# getLogs width cap (unchanged):
# consensus_max_block_range = 20000
# Route deep reads (incl. old getLogs) to archive backends:
# archive_block_threshold = 1000000
# restrict_archive_node_traffic = true
```

## Tests

- `TestRewriteRequest`: too-far-behind (rejected), within-bounds (allowed), `earliest` (rejected) for state reads (generalized across `eth_call`/`eth_getBalance`/`eth_getTransactionCount` + an EIP-1898 case); plus getLogs old-`fromBlock`/`earliest` **not** depth-limited (generalized to `eth_newFilter`).
- `backend_test.go`: `TestGetLogsRequiresArchive` (recent/old/earliest/latest/blockHash/custom-threshold/fail-safe-on-parse-error) and `TestHasArchiveBackend`.
- `go build ./...`, `go vet`, the full proxyd package suite, and `gofmt` all pass.
