### PR TITLE
proxyd: exempt eth_getLogs from consensus_max_blocks_back, route old ranges to archive

### DIFF
--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -135,6 +135,11 @@ var (
 		Message:       "address is sanctioned",
 		HTTPErrorCode: 403,
 	}
+	ErrArchiveBackendUnavailable = &RPCErr{
+		Code:          JSONRPCErrorInternal - 22,
+		Message:       "no archive backend available to serve historical eth_getLogs range",
+		HTTPErrorCode: 503,
+	}
 
 	ErrBackendUnexpectedJSONRPC = errors.New("backend returned an unexpected JSON-RPC response")
 
@@ -802,6 +807,18 @@ func (bg *BackendGroup) GetRoutingStrategy() RoutingStrategy {
 	return bg.routingStrategy
 }
 
+// hasArchiveBackend reports whether the group is configured with at least one archive
+// backend (regardless of current health). Used to tell a transient archive outage apart
+// from a deployment that simply runs no archive backends.
+func (bg *BackendGroup) hasArchiveBackend() bool {
+	for _, b := range bg.Backends {
+		if b.archive {
+			return true
+		}
+	}
+	return false
+}
+
 func (bg *BackendGroup) Fallbacks() []*Backend {
 	fallbacks := []*Backend{}
 	for _, a := range bg.Backends {
@@ -850,11 +867,23 @@ func (bg *BackendGroup) Forward(ctx context.Context, rpcReqs []*RPCReq, isBatch 
 
 	// Determine if archive is required
 	archiveRequired := false
+	getLogsArchiveRequired := false
 	for _, req := range rpcReqs {
 		// All debug_* methods require archive nodes
 		if strings.HasPrefix(req.Method, "debug_") {
 			archiveRequired = true
 			break
+		}
+
+		// eth_getLogs carries its block bounds in a filter object (fromBlock/toBlock),
+		// not a positional param, so it can't use blockParamIndex. Route to archive when
+		// its oldest bound is beyond the archive threshold, or when it pins a blockHash.
+		if req.Method == "eth_getLogs" {
+			if bg.Consensus != nil && getLogsRequiresArchive(req, bg.Consensus.GetLatestBlockNumber(), bg.ArchiveBlockThreshold) {
+				archiveRequired = true
+				getLogsArchiveRequired = true
+			}
+			continue
 		}
 
 		idx, ok := blockParamIndex[req.Method]
@@ -898,6 +927,11 @@ func (bg *BackendGroup) Forward(ctx context.Context, rpcReqs []*RPCReq, isBatch 
 		}
 		if len(archiveBackends) > 0 {
 			backends = archiveBackends
+		} else if getLogsArchiveRequired && bg.hasArchiveBackend() {
+			// The group runs archive backends but none are currently healthy. Serving an
+			// old eth_getLogs range from a full node would return a silent empty result for
+			// pruned blocks, so fail loudly instead of best-effort routing to a full node.
+			return nil, "", ErrArchiveBackendUnavailable
 		}
 		rpcArchiveRequestsTotal.Inc()
 	} else if bg.RestrictArchiveNodeTraffic {
@@ -1877,6 +1911,28 @@ func requiresArchiveForBlock(blockParam string, latestBlockNumber hexutil.Uint64
 		}
 	}
 	return false
+}
+
+// getLogsRequiresArchive reports whether an eth_getLogs request must be served by an
+// archive backend: either it pins a blockHash (not bounded by number) or its oldest
+// bound (fromBlock) is far enough behind head to require archive data. fromBlock/toBlock
+// tags are already resolved to block numbers by the request rewriter at this point.
+func getLogsRequiresArchive(req *RPCReq, latestBlockNumber hexutil.Uint64, archiveBlockThreshold uint64) bool {
+	var params []map[string]interface{}
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		// Fail safe: if the bounds can't be parsed, route to archive rather than risk
+		// serving an old (pruned) range from a full node that returns a silent empty set.
+		return true
+	}
+	if len(params) == 0 {
+		return false
+	}
+	filter := params[0]
+	if _, ok := filter["blockHash"]; ok {
+		return true
+	}
+	// fromBlock is the oldest bound; if it requires archive, the whole query does.
+	return requiresArchiveForBlock(extractBlockParameter(filter["fromBlock"]), latestBlockNumber, archiveBlockThreshold)
 }
 
 // receiptMethods maps RPC methods that return receipt arrays.

--- a/proxyd/backend_test.go
+++ b/proxyd/backend_test.go
@@ -263,6 +263,103 @@ func TestRequiresArchiveForBlock(t *testing.T) {
 	}
 }
 
+func TestGetLogsRequiresArchive(t *testing.T) {
+	latest := hexutil.Uint64(1000)
+
+	tests := []struct {
+		name      string
+		filter    map[string]interface{}
+		latest    hexutil.Uint64
+		threshold uint64
+		expected  bool
+	}{
+		{
+			name:     "no block bounds (defaults to latest)",
+			filter:   map[string]interface{}{"address": "0x123"},
+			latest:   latest,
+			expected: false,
+		},
+		{
+			name:     "recent fromBlock",
+			filter:   map[string]interface{}{"fromBlock": "0x3e0"}, // 992, 8 behind head
+			latest:   latest,
+			expected: false,
+		},
+		{
+			name:     "old fromBlock",
+			filter:   map[string]interface{}{"fromBlock": "0x100"}, // 256, 744 behind head
+			latest:   latest,
+			expected: true,
+		},
+		{
+			name:     "earliest fromBlock",
+			filter:   map[string]interface{}{"fromBlock": "earliest"},
+			latest:   latest,
+			expected: true,
+		},
+		{
+			name:     "latest fromBlock",
+			filter:   map[string]interface{}{"fromBlock": "latest"},
+			latest:   latest,
+			expected: false,
+		},
+		{
+			name:     "blockHash pins archive",
+			filter:   map[string]interface{}{"blockHash": "0xabcdef"},
+			latest:   latest,
+			expected: true,
+		},
+		{
+			// oldest bound governs: old fromBlock requires archive even with a recent toBlock.
+			name:     "old fromBlock with recent toBlock",
+			filter:   map[string]interface{}{"fromBlock": "0x100", "toBlock": "0x3e0"},
+			latest:   latest,
+			expected: true,
+		},
+		{
+			name:      "custom threshold: old fromBlock",
+			filter:    map[string]interface{}{"fromBlock": "0x1f4"}, // 500, 500 behind head
+			latest:    latest,
+			threshold: 500,
+			expected:  true,
+		},
+		{
+			name:      "custom threshold: recent fromBlock",
+			filter:    map[string]interface{}{"fromBlock": "0x3e0"}, // 992
+			latest:    latest,
+			threshold: 500,
+			expected:  false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := &RPCReq{
+				Method: "eth_getLogs",
+				Params: mustMarshalJSON([]map[string]interface{}{test.filter}),
+			}
+			result := getLogsRequiresArchive(req, test.latest, test.threshold)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+
+	t.Run("empty params", func(t *testing.T) {
+		req := &RPCReq{Method: "eth_getLogs", Params: mustMarshalJSON([]map[string]interface{}{})}
+		assert.False(t, getLogsRequiresArchive(req, latest, 0))
+	})
+
+	t.Run("unparseable params fail safe to archive", func(t *testing.T) {
+		req := &RPCReq{Method: "eth_getLogs", Params: json.RawMessage(`{"not":"an array"}`)}
+		assert.True(t, getLogsRequiresArchive(req, latest, 0))
+	})
+}
+
+func TestHasArchiveBackend(t *testing.T) {
+	assert.False(t, (&BackendGroup{}).hasArchiveBackend())
+	assert.False(t, (&BackendGroup{Backends: []*Backend{{archive: false}}}).hasArchiveBackend())
+	assert.True(t, (&BackendGroup{Backends: []*Backend{{archive: false}, {archive: true}}}).hasArchiveBackend())
+}
+
 func TestContainsArchiveRequiredError(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/proxyd/example.config.toml
+++ b/proxyd/example.config.toml
@@ -100,21 +100,27 @@ backends = ["infura"]
 # consensus_max_block_lag = 16
 # Maximum block range (for eth_getLogs method), no default
 # consensus_max_block_range = 20000
-# Maximum number of blocks behind head a block-addressed read may target, no default.
-# When set, requests whose block parameter is more than this many blocks behind the
-# latest block are rejected (applies to eth_call, eth_getBalance, eth_getCode,
-# eth_getTransactionCount, eth_getStorageAt, eth_getProof, and eth_getLogs from/toBlock).
+# Maximum number of blocks behind head a block-addressed STATE read may target, no default.
+# When set, requests whose block parameter is more than this many blocks behind the latest
+# block are rejected (applies to eth_call, eth_getBalance, eth_getCode,
+# eth_getTransactionCount, eth_getStorageAt, and eth_getProof). eth_getLogs is exempt: its
+# cost is bounded by block-range width (consensus_max_block_range), not depth, and old
+# ranges are routed to archive backends instead of being rejected.
 # consensus_max_blocks_back = 100000
 # Minimum peer count, default 3
 # consensus_min_peer_count = 4
 # Restrict archive node traffic to only archive-required requests, default false
 # When enabled, archive backends (archive=true) will only receive traffic for:
-# - Requests that explicitly require archive data (old blocks, blockHash queries)
+# - Requests that explicitly require archive data (old blocks, blockHash queries, and
+#   eth_getLogs whose range starts before archive_block_threshold)
 # - Regular requests when no non-archive backends are available (fallback)
 # restrict_archive_node_traffic = true
 # Number of blocks from head beyond which requests are routed to archive backends.
 # Default: 128 (standard full-node state window)
 # archive_block_threshold = 1000000
+# Note: if the group has archive backends configured but none are currently healthy, an
+# eth_getLogs whose range requires archive fails with an explicit error (HTTP 503) rather
+# than being served from a full node, which would silently return [] for pruned blocks.
 
 [backend_groups.alchemy]
 backends = ["alchemy"]

--- a/proxyd/rewriter.go
+++ b/proxyd/rewriter.go
@@ -200,6 +200,13 @@ func shouldReturnNullOnOutOfRange(method string) bool {
 }
 
 func rewriteRange(rctx RewriteContext, req *RPCReq, res *RPCRes, pos int) (RewriteResult, error) {
+	// eth_getLogs/eth_newFilter cost scales with block-range width, not with how far
+	// behind head the range sits (receipts are age-independent reads), so the
+	// consensus_max_blocks_back "too far behind head" guard does not apply here. Old
+	// ranges are sent to archive backends by the archive-routing layer instead. The
+	// range-width cap (maxBlockRange) and future-block check below still apply.
+	rctx.maxBlocksBack = 0
+
 	var p []map[string]interface{}
 	err := json.Unmarshal(req.Params, &p)
 	if err != nil {

--- a/proxyd/rewriter_test.go
+++ b/proxyd/rewriter_test.go
@@ -221,6 +221,28 @@ func TestRewriteRequest(t *testing.T) {
 				require.Equal(t, hexutil.Uint64(100).String(), p[0]["toBlock"])
 			},
 		},
+		{
+			// state reads at this depth are rejected (see "eth_getCode too far behind
+			// head"), but getLogs is range-axis, not depth-axis, so it must be allowed.
+			name: "eth_getLogs fromBlock far behind head is not depth-limited",
+			args: args{
+				rctx:        RewriteContext{latest: hexutil.Uint64(100), maxBlocksBack: 30},
+				req:         &RPCReq{Method: "eth_getLogs", Params: mustMarshalJSON([]map[string]interface{}{{"fromBlock": hexutil.Uint64(50).String(), "toBlock": hexutil.Uint64(60).String()}})},
+				res:         nil,
+				skipeip1898: false,
+			},
+			expected: RewriteNone,
+		},
+		{
+			name: "eth_getLogs earliest is not depth-limited",
+			args: args{
+				rctx:        RewriteContext{latest: hexutil.Uint64(100), maxBlocksBack: 30},
+				req:         &RPCReq{Method: "eth_getLogs", Params: mustMarshalJSON([]map[string]interface{}{{"fromBlock": "earliest", "toBlock": hexutil.Uint64(60).String()}})},
+				res:         nil,
+				skipeip1898: false,
+			},
+			expected: RewriteNone,
+		},
 		/* required parameter at pos 0 */
 		{
 			name: "debug_getRawReceipts latest",


### PR DESCRIPTION
## Summary

Refines the `consensus_max_blocks_back` feature so it applies to the right requests, and makes old `eth_getLogs` ranges route to archive backends instead of being rejected or silently mis-served.

> **Stacked on #35.** This branch is based on `proxyd-consensus-max-blocks-back` (PR #35), which is still open. Review/merge #35 first, or retarget this PR to `main` once #35 lands.

## Why

`eth_getLogs` cost scales with **block-range width**, not with how far behind head the range sits — receipts are age-independent reads (static files), so a *narrow* query at an old block is cheap. The depth cap (`consensus_max_blocks_back`) is therefore the wrong axis for getLogs: it was rejecting cheap, legitimate historical event queries (e.g. a dapp backfilling logs for a contract).

The right tools for getLogs are the **range-width cap** (`consensus_max_block_range`) for cost, and **archive routing** for old ranges (full nodes prune old receipts and return a silent `[]` for pruned blocks).

## Changes

1. **Exempt `eth_getLogs`/`eth_newFilter` from the depth cap** (`rewriter.go`): `rewriteRange` sets `maxBlocksBack = 0`. The range-width cap and future-block (`ErrRewriteBlockOutOfRange`) checks still apply.

2. **Route old `eth_getLogs` to archive** (`backend.go`): new `getLogsRequiresArchive` helper flags archive when the oldest bound (`fromBlock`) is beyond `archive_block_threshold`, or the query pins a `blockHash`. (`fromBlock`/`toBlock` tags are already resolved to numbers by the rewriter at this point.) Fails *safe* (routes to archive) if the filter can't be parsed.

3. **Fail loud on archive outage** (`backend.go`): if the group runs archive backends but none are currently healthy, an old getLogs returns `ErrArchiveBackendUnavailable` (HTTP 503) instead of silently falling back to a full node and returning `[]` for pruned blocks. Scoped to groups that actually configure archive backends, so no-archive deployments are unaffected.

## Tests

- `rewriter_test.go`: getLogs with an old `fromBlock`/`earliest` + `maxBlocksBack` set is **not** rejected (auto-generalized to `eth_newFilter`).
- `backend_test.go`: `TestGetLogsRequiresArchive` (recent/old/earliest/latest/blockHash/threshold/fail-safe), `TestHasArchiveBackend`.
- `go build`, `go vet`, full proxyd package suite, and `gofmt` all clean.

## Note for operators

`consensus_max_blocks_back` now documents that it applies to **state reads only**; getLogs is bounded by `consensus_max_block_range` and archive routing. See updated `example.config.toml`.