### PR TITLE
proxyd: clearer error for eth_sendTransaction (point users to eth_sendRawTransaction)

### DIFF
--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -68,6 +68,11 @@ var (
 		Message:       "rpc method is not whitelisted",
 		HTTPErrorCode: 403,
 	}
+	ErrEthSendTransactionUnsupported = &RPCErr{
+		Code:          notFoundRpcError,
+		Message:       "eth_sendTransaction is not supported; sign the transaction and submit it with eth_sendRawTransaction",
+		HTTPErrorCode: 403,
+	}
 	ErrBackendOffline = &RPCErr{
 		Code:          JSONRPCErrorInternal - 10,
 		Message:       "backend offline",
@@ -161,6 +166,18 @@ func ErrInvalidParams(msg string) *RPCErr {
 		Message:       msg,
 		HTTPErrorCode: 400,
 	}
+}
+
+// unsupportedMethodError returns the error to send for a method proxyd will not forward.
+// eth_sendTransaction gets a dedicated, actionable message: it asks the node to hold the
+// account key and sign the transaction, which a public endpoint does not do, so the fix
+// is to sign client-side and use eth_sendRawTransaction. Every other non-whitelisted
+// method gets the standard (operator-customizable) not-whitelisted error.
+func unsupportedMethodError(method string) *RPCErr {
+	if method == "eth_sendTransaction" {
+		return ErrEthSendTransactionUnsupported
+	}
+	return ErrMethodNotWhitelisted
 }
 
 type Backend struct {
@@ -1447,7 +1464,7 @@ func (w *WSProxier) prepareClientMsg(msg []byte) (*RPCReq, error) {
 	}
 
 	if !w.methodWhitelist.Has(req.Method) {
-		return req, ErrMethodNotWhitelisted
+		return req, unsupportedMethodError(req.Method)
 	}
 
 	return req, nil

--- a/proxyd/backend_test.go
+++ b/proxyd/backend_test.go
@@ -360,6 +360,14 @@ func TestHasArchiveBackend(t *testing.T) {
 	assert.True(t, (&BackendGroup{Backends: []*Backend{{archive: false}, {archive: true}}}).hasArchiveBackend())
 }
 
+func TestUnsupportedMethodError(t *testing.T) {
+	// eth_sendTransaction gets the dedicated, actionable message.
+	assert.Equal(t, ErrEthSendTransactionUnsupported, unsupportedMethodError("eth_sendTransaction"))
+	// Everything else falls back to the standard not-whitelisted error.
+	assert.Equal(t, ErrMethodNotWhitelisted, unsupportedMethodError("eth_sendRawTransaction"))
+	assert.Equal(t, ErrMethodNotWhitelisted, unsupportedMethodError("foo_bar"))
+}
+
 func TestContainsArchiveRequiredError(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/proxyd/integration_tests/validation_test.go
+++ b/proxyd/integration_tests/validation_test.go
@@ -12,6 +12,7 @@ import (
 
 const (
 	notWhitelistedResponse        = `{"jsonrpc":"2.0","error":{"code":-32601,"message":"rpc method is not whitelisted custom message"},"id":999}`
+	ethSendTransactionResponse    = `{"jsonrpc":"2.0","error":{"code":-32601,"message":"eth_sendTransaction is not supported; sign the transaction and submit it with eth_sendRawTransaction"},"id":999}`
 	parseErrResponse              = `{"jsonrpc":"2.0","error":{"code":-32700,"message":"parse error"},"id":null}`
 	invalidJSONRPCVersionResponse = `{"error":{"code":-32600,"message":"invalid JSON-RPC version"},"id":null,"jsonrpc":"2.0"}`
 	invalidIDResponse             = `{"error":{"code":-32600,"message":"invalid ID"},"id":null,"jsonrpc":"2.0"}`
@@ -89,6 +90,14 @@ func TestSingleRPCValidation(t *testing.T) {
 			"not whitelisted method",
 			"{\"jsonrpc\": \"2.0\", \"method\": \"subtract\", \"params\": [42, 23], \"id\": 999}",
 			notWhitelistedResponse,
+			403,
+		},
+		{
+			// eth_sendTransaction gets its own actionable message, not the generic
+			// (here custom-configured) not-whitelisted one.
+			"eth_sendTransaction unsupported message",
+			"{\"jsonrpc\": \"2.0\", \"method\": \"eth_sendTransaction\", \"params\": [], \"id\": 999}",
+			ethSendTransactionResponse,
 			403,
 		},
 	}

--- a/proxyd/server.go
+++ b/proxyd/server.go
@@ -603,8 +603,9 @@ func (s *Server) handleBatchRPC(ctx context.Context, reqs []json.RawMessage, isL
 				"req_id", GetReqID(ctx),
 				"method", parsedReq.Method,
 			)
-			RecordRPCError(ctx, BackendProxyd, MethodUnknown, ErrMethodNotWhitelisted)
-			responses[i] = NewRPCErrorRes(parsedReq.ID, ErrMethodNotWhitelisted)
+			rpcErr := unsupportedMethodError(parsedReq.Method)
+			RecordRPCError(ctx, BackendProxyd, MethodUnknown, rpcErr)
+			responses[i] = NewRPCErrorRes(parsedReq.ID, rpcErr)
 			continue
 		}
 


### PR DESCRIPTION
## What

When a client calls `eth_sendTransaction` against the public endpoint, proxyd rejects it with the generic `-32601 "rpc method is not whitelisted"` (some clients, e.g. viem, render this as **"Method not allowed"**). That gives no hint at the actual problem or fix.

This returns a dedicated, actionable message instead:

```
eth_sendTransaction is not supported; sign the transaction and submit it with eth_sendRawTransaction
```

## Why

`eth_sendTransaction` asks the **node** to hold the account's private key and sign the transaction. A public RPC endpoint holds no keys, so it's (correctly) not whitelisted — the user's client should sign locally and submit via `eth_sendRawTransaction`. The error now says exactly that.

There's no strict JSON-RPC convention for this case; the chosen message follows the "state what's wrong + how to fix" pattern (keeps `-32601`, same as the not-whitelisted error it replaces for this method).

## How

- New `ErrEthSendTransactionUnsupported` error (same `-32601` / HTTP 403 as `ErrMethodNotWhitelisted`).
- Small shared helper `unsupportedMethodError(method)` — returns the dedicated error for `eth_sendTransaction`, otherwise the standard not-whitelisted error.
- Wired into **both** rejection sites: the HTTP path (`server.go`) and the WS path (`backend.go` `prepareClientMsg`), so behavior is consistent across transports.
- Other non-whitelisted methods are unchanged and still honor the operator's `whitelist_error_message` override (the dedicated `eth_sendTransaction` message is intentionally *not* affected by that global override).

## Tests

- `TestUnsupportedMethodError` (unit): the helper maps `eth_sendTransaction` to the dedicated error and everything else to `ErrMethodNotWhitelisted`.
- `TestSingleRPCValidation` (integration): new case asserts the end-to-end HTTP response for `eth_sendTransaction`, and that the configured `whitelist_error_message` does **not** override it (the existing not-whitelisted case still gets the custom message).
- `go build`, `go vet`, full proxyd unit suite, integration validation test, and `gofmt` all pass.